### PR TITLE
Evento Cancelamento de Insucesso na Entrega do CT-e - 110191

### DIFF
--- a/CTe.Classes/Servicos/Evento/Flags/CTeTipoEvento.cs
+++ b/CTe.Classes/Servicos/Evento/Flags/CTeTipoEvento.cs
@@ -55,6 +55,8 @@ namespace CTe.Classes.Servicos.Evento.Flags
         CancelamentodoComprovantedeEntrega = 110181,
         [XmlEnum("110190")]
         InsucessoNaEntregaDoCte = 110190,
+        [XmlEnum("110191")]
+        CancelamentodoInsucessoNaEntregaDoCte = 110191,
         //Evento: Fisco
         [XmlEnum("310620")]
         RegistrodePassagem = 310620,


### PR DESCRIPTION
Lendo a Versão 1.01, observei mais um Evento Adicionado.
Cancelamento de Insucesso na Entrega do CT-e - 110191 (CTe_Nota_Tecnica_2023_002_v1.01 Evento de Insucesso da Entrega - Pag 8)