### PR TITLE
CRT SimplesNacionalMEI para ObterICMSGeral

### DIFF
--- a/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
+++ b/NFe.Utils/Tributacao/Estadual/ICMSGeral.cs
@@ -70,6 +70,7 @@ namespace NFe.Utils.Tributacao.Estadual
 
             switch (crt)
             {
+                case CRT.SimplesNacionalMei:
                 case CRT.SimplesNacional:
                     switch (CST)
                     {


### PR DESCRIPTION
bugfix/ICMSGeral_CRT_SimplesNacionalMei: adicionado opção pendente CRT.SimplesNacionalMei no switch case do metodo ICMSGeral.ObterICMSBasico() em NFe.Utils/Tributacao/Estadual/ICMSGeral.cs