### PR TITLE
Garantindo que instancia de serviço na CTe esteja sempre instanciada e seja utilizada corretamente

### DIFF
--- a/CTe.Servicos/ConsultaProtocolo/ConsultaProtcoloServico.cs
+++ b/CTe.Servicos/ConsultaProtocolo/ConsultaProtcoloServico.cs
@@ -43,54 +43,60 @@ namespace CTe.Servicos.ConsultaProtocolo
     {
         public retConsSitCTe ConsultaProtocolo(string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            if (configuracaoServico.IsValidaSchemas)
-                consSitCTe.ValidarSchema(configuracaoServico);
+            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configServico);
 
-            consSitCTe.SalvarXmlEmDisco(configuracaoServico);
+            if (configServico.IsValidaSchemas)
+                consSitCTe.ValidarSchema(configServico);
 
-            var webService = WsdlFactory.CriaWsdlConsultaProtocolo(configuracaoServico);
+            consSitCTe.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlConsultaProtocolo(configServico);
             var retornoXml = webService.cteConsultaCT(consSitCTe.CriaRequestWs());
 
             var retorno = retConsSitCTe.LoadXml(retornoXml.OuterXml, consSitCTe);
-            retorno.SalvarXmlEmDisco(chave, configuracaoServico);
+            retorno.SalvarXmlEmDisco(chave, configServico);
 
             return retorno;
         }
 
         public retConsSitCTe ConsultaProtocoloV4(string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            if (configuracaoServico.IsValidaSchemas)
-                consSitCTe.ValidarSchema(configuracaoServico);
+            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configServico);
 
-            consSitCTe.SalvarXmlEmDisco(configuracaoServico);
+            if (configServico.IsValidaSchemas)
+                consSitCTe.ValidarSchema(configServico);
 
-            var webService = WsdlFactory.CriaWsdlConsultaProtocoloV4(configuracaoServico);
+            consSitCTe.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlConsultaProtocoloV4(configServico);
             var retornoXml = webService.cteConsultaCT(consSitCTe.CriaRequestWs());
 
             var retorno = retConsSitCTe.LoadXml(retornoXml.OuterXml, consSitCTe);
-            retorno.SalvarXmlEmDisco(chave, configuracaoServico);
+            retorno.SalvarXmlEmDisco(chave, configServico);
 
             return retorno;
         }
 
         public async Task<retConsSitCTe> ConsultaProtocoloAsync(string chave, ConfiguracaoServico configuracaoServico = null)
         {
-            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configuracaoServico);
-            
-            if (configuracaoServico.IsValidaSchemas)
-                consSitCTe.ValidarSchema(configuracaoServico);
-            
-            consSitCTe.SalvarXmlEmDisco(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlConsultaProtocolo(configuracaoServico);
+            var consSitCTe = ClassesFactory.CriarconsSitCTe(chave, configServico);
+
+            if (configServico.IsValidaSchemas)
+                consSitCTe.ValidarSchema(configServico);
+
+            consSitCTe.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlConsultaProtocolo(configServico);
             var retornoXml = await webService.cteConsultaCTAsync(consSitCTe.CriaRequestWs());
 
             var retorno = retConsSitCTe.LoadXml(retornoXml.OuterXml, consSitCTe);
-            retorno.SalvarXmlEmDisco(chave, configuracaoServico);
+            retorno.SalvarXmlEmDisco(chave, configServico);
 
             return retorno;
         }

--- a/CTe.Servicos/ConsultaRecibo/ConsultaReciboServico.cs
+++ b/CTe.Servicos/ConsultaRecibo/ConsultaReciboServico.cs
@@ -50,36 +50,40 @@ namespace CTe.Servicos.ConsultaRecibo
 
         public retConsReciCTe Consultar(ConfiguracaoServico configuracaoServico = null)
         {
-            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo, configuracaoServico);
-            
-            if (configuracaoServico.IsValidaSchemas)
-                consReciCTe.ValidarSchema(configuracaoServico);
-            
-            consReciCTe.SalvarXmlEmDisco(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteRetRecepcao(configuracaoServico);
+            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo, configServico);
+
+            if (configServico.IsValidaSchemas)
+                consReciCTe.ValidarSchema(configServico);
+
+            consReciCTe.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteRetRecepcao(configServico);
             var retornoXml = webService.cteRetRecepcao(consReciCTe.CriaRequestWs());
 
             var retorno = retConsReciCTe.LoadXml(retornoXml.OuterXml, consReciCTe);
-            retorno.SalvarXmlEmDisco(configuracaoServico);
+            retorno.SalvarXmlEmDisco(configServico);
 
             return retorno;
         }
 
         public async Task<retConsReciCTe> ConsultarAsync(ConfiguracaoServico configuracaoServico = null)
         {
-            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo, configuracaoServico);
-            
-            if (configuracaoServico.IsValidaSchemas)
-                consReciCTe.ValidarSchema(configuracaoServico);
-            
-            consReciCTe.SalvarXmlEmDisco(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteRetRecepcao(configuracaoServico);
+            var consReciCTe = ClassesFactory.CriaConsReciCTe(_recibo, configServico);
+
+            if (configServico.IsValidaSchemas)
+                consReciCTe.ValidarSchema(configServico);
+
+            consReciCTe.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteRetRecepcao(configServico);
             var retornoXml = await webService.cteRetRecepcaoAsync(consReciCTe.CriaRequestWs());
 
             var retorno = retConsReciCTe.LoadXml(retornoXml.OuterXml, consReciCTe);
-            retorno.SalvarXmlEmDisco(configuracaoServico);
+            retorno.SalvarXmlEmDisco(configServico);
 
             return retorno;
         }

--- a/CTe.Servicos/DistribuicaoDFe/ServicoCTeDistribuicaoDFe.cs
+++ b/CTe.Servicos/DistribuicaoDFe/ServicoCTeDistribuicaoDFe.cs
@@ -79,6 +79,7 @@ namespace CTe.Servicos.DistribuicaoDFe
         public RetornoCteDistDFeInt CTeDistDFeInteresse(string ufAutor, string documento, string ultNSU = "0", string nSU = "0", ConfiguracaoServico configuracaoServico = null)
         {
             var configServico = configuracaoServico ?? _configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             distDFeInt pedDistDFeInt;
             XmlDocument dadosConsulta;
             var ws = InicializaCTeDistDFeInteresse(documento, ultNSU, nSU, out pedDistDFeInt, out dadosConsulta, configServico);

--- a/CTe.Servicos/EnviarCte/ServicoEnviarCte.cs
+++ b/CTe.Servicos/EnviarCte/ServicoEnviarCte.cs
@@ -14,10 +14,10 @@ namespace CTe.Servicos.EnviarCte
         public RetornoEnviarCte Enviar(int lote, Classes.CTe cte, ConfiguracaoServico configuracaoServico = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
-            
+
             ServicoCTeRecepcao servicoRecepcao = new ServicoCTeRecepcao();
 
-            retEnviCte retEnviCte = servicoRecepcao.CTeRecepcao(lote, new List<Classes.CTe> {cte}, configServico);
+            retEnviCte retEnviCte = servicoRecepcao.CTeRecepcao(lote, new List<Classes.CTe> { cte }, configServico);
 
             if (retEnviCte.cStat != 103)
             {
@@ -27,7 +27,6 @@ namespace CTe.Servicos.EnviarCte
             ConsultaReciboServico servicoConsultaRecibo = new ConsultaReciboServico(retEnviCte.infRec.nRec);
 
             retConsReciCTe retConsReciCTe = servicoConsultaRecibo.Consultar(configServico);
-
 
             cteProc cteProc = null;
             if (retConsReciCTe.cStat == 104)
@@ -54,6 +53,7 @@ namespace CTe.Servicos.EnviarCte
         public async Task<RetornoEnviarCte> EnviarAsync(int lote, Classes.CTe cte, ConfiguracaoServico configuracaoServico = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             ServicoCTeRecepcao servicoRecepcao = new ServicoCTeRecepcao();
 
             retEnviCte retEnviCte = await servicoRecepcao.CTeRecepcaoAsync(lote, new List<Classes.CTe> { cte }, configServico);

--- a/CTe.Servicos/Eventos/EventoCancelamento.cs
+++ b/CTe.Servicos/Eventos/EventoCancelamento.cs
@@ -72,30 +72,33 @@ namespace CTe.Servicos.Eventos
 
         public retEventoCTe Cancelar(ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var evento = ClassesFactory.CriaEvCancCTe(_justificativa, _numeroProtocolo);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Cancelamento, _sequenciaEvento, _cte.Chave(), _cte.infCte.emit.CNPJ, evento, configuracaoServico);
-            RetornoSefaz = new ServicoController().Executar(_cte, _sequenciaEvento, evento, CTeTipoEvento.Cancelamento, configuracaoServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Cancelamento, _sequenciaEvento, _cte.Chave(), _cte.infCte.emit.CNPJ, evento, configServico);
+            RetornoSefaz = new ServicoController().Executar(_cte, _sequenciaEvento, evento, CTeTipoEvento.Cancelamento, configServico);
 
             return RetornoSefaz;
         }
 
         public retEventoCTe CancelarOs(ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var evento = ClassesFactory.CriaEvCancCTe(_justificativa, _numeroProtocolo);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Cancelamento, _sequenciaEvento, _cteOs.Chave(), _cteOs.InfCte.emit.CNPJ, evento, configuracaoServico);
-            RetornoSefaz = new ServicoController().Executar(_cteOs, _sequenciaEvento, evento, CTeTipoEvento.Cancelamento, configuracaoServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Cancelamento, _sequenciaEvento, _cteOs.Chave(), _cteOs.InfCte.emit.CNPJ, evento, configServico);
+            RetornoSefaz = new ServicoController().Executar(_cteOs, _sequenciaEvento, evento, CTeTipoEvento.Cancelamento, configServico);
 
             return RetornoSefaz;
         }
 
         public async Task<retEventoCTe> CancelarAsync(ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var evento = ClassesFactory.CriaEvCancCTe(_justificativa, _numeroProtocolo);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Cancelamento, _sequenciaEvento, _cte.Chave(), _cte.infCte.emit.CNPJ, evento, configuracaoServico);
-            RetornoSefaz = await new ServicoController().ExecutarAsync(_cte, _sequenciaEvento, evento, CTeTipoEvento.Cancelamento, configuracaoServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Cancelamento, _sequenciaEvento, _cte.Chave(), _cte.infCte.emit.CNPJ, evento, configServico);
+            RetornoSefaz = await new ServicoController().ExecutarAsync(_cte, _sequenciaEvento, evento, CTeTipoEvento.Cancelamento, configServico);
 
             return RetornoSefaz;
         }

--- a/CTe.Servicos/Eventos/FactoryEvento.cs
+++ b/CTe.Servicos/Eventos/FactoryEvento.cs
@@ -47,7 +47,8 @@ namespace CTe.Servicos.Eventos
         //Vou manter para evitar quebra de código pois a classe e o metodo são publicos
         public static eventoCTe CriaEvento(CTeEletronico cte, CTeTipoEvento cTeTipoEvento, int sequenciaEvento, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
         {
-            return CriaEvento(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            return CriaEvento(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configServico);
         }
 
         public static eventoCTe CriaEvento(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)

--- a/CTe.Servicos/Eventos/ServicoController.cs
+++ b/CTe.Servicos/Eventos/ServicoController.cs
@@ -50,64 +50,74 @@ namespace CTe.Servicos.Eventos
     {
         public retEventoCTe Executar(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento, ConfiguracaoServico configuracaoServico = null)
         {
-            return Executar(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            return Executar(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configServico);
         }
 
         public retEventoCTe Executar(CteEletronicoOS cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento, ConfiguracaoServico configuracaoServico = null)
         {
-            return Executar(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.InfCte.emit.CNPJ, container, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            return Executar(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.InfCte.emit.CNPJ, container, configServico);
         }
 
         public async Task<retEventoCTe> ExecutarAsync(CteEletronico cte, int sequenciaEvento, EventoContainer container, CTeTipoEvento cTeTipoEvento, ConfiguracaoServico configuracaoServico = null)
         {
-            return await ExecutarAsync(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            return await ExecutarAsync(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configServico);
         }
 
         public retEventoCTe Executar(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
         {
-            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configuracaoServico);
-            evento.Assina(configuracaoServico);
-            
-            if (configuracaoServico.IsValidaSchemas)
-                evento.ValidarSchema(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico);
+            evento.Assina(configServico);
 
-            evento.SalvarXmlEmDisco(configuracaoServico);
+            if (configuracaoServico.IsValidaSchemas)
+                evento.ValidarSchema(configServico);
+
+            evento.SalvarXmlEmDisco(configServico);
 
             XmlNode retornoXml = null;
 
             if (evento.versao == versao.ve200 || evento.versao == versao.ve300)
             {
-                var webService = WsdlFactory.CriaWsdlCteEvento(configuracaoServico);
+                var webService = WsdlFactory.CriaWsdlCteEvento(configServico);
                 retornoXml = webService.cteRecepcaoEvento(evento.CriaXmlRequestWs());
             }
 
             if (evento.versao == versao.ve400)
             {
-                var webService = WsdlFactory.CriaWsdlCteEventoV4(configuracaoServico);
+                var webService = WsdlFactory.CriaWsdlCteEventoV4(configServico);
                 retornoXml = webService.cteRecepcaoEvento(evento.CriaXmlRequestWs());
             }
 
             var retorno = retEventoCTe.LoadXml(retornoXml.OuterXml, evento);
-            retorno.SalvarXmlEmDisco(configuracaoServico);
+            retorno.SalvarXmlEmDisco(configServico);
 
             return retorno;
         }
 
-        public async Task<retEventoCTe> ExecutarAsync(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
+        public async Task<retEventoCTe> ExecutarAsync(CTeTipoEvento cTeTipoEvento,
+            int sequenciaEvento,
+            string chave, string
+            cnpj, EventoContainer container,
+            ConfiguracaoServico configuracaoServico = null)
         {
-            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configuracaoServico);
-            evento.Assina(configuracaoServico);
-            
-            if (configuracaoServico.IsValidaSchemas)
-                evento.ValidarSchema(configuracaoServico);
-            
-            evento.SalvarXmlEmDisco(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteEvento(configuracaoServico);
+            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico);
+            evento.Assina(configServico);
+
+            if (configServico.IsValidaSchemas)
+                evento.ValidarSchema(configServico);
+
+            evento.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteEvento(configServico);
             var retornoXml = await webService.cteRecepcaoEventoAsync(evento.CriaXmlRequestWs());
 
             var retorno = retEventoCTe.LoadXml(retornoXml.OuterXml, evento);
-            retorno.SalvarXmlEmDisco(configuracaoServico);
+            retorno.SalvarXmlEmDisco(configServico);
 
             return retorno;
         }

--- a/CTe.Servicos/Factory/WsdlFactory.cs
+++ b/CTe.Servicos/Factory/WsdlFactory.cs
@@ -134,9 +134,11 @@ namespace CTe.Servicos.Factory
 
         public static CteRecepcaoEventoV4 CriaWsdlCteEventoV4(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
         {
-            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcaoEvento;
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
+            var url = UrlHelper.ObterUrlServico(configServico).CteRecepcaoEvento;
+
+            var configuracaoWsdl = CriaConfiguracao(url, configServico, certificado);
 
             return new CteRecepcaoEventoV4(configuracaoWsdl);
         }

--- a/CTe.Servicos/Inutilizacao/InutilizacaoServico.cs
+++ b/CTe.Servicos/Inutilizacao/InutilizacaoServico.cs
@@ -78,32 +78,36 @@ namespace CTe.Servicos.Inutilizacao
 
         public retInutCTe Inutilizar(ConfiguracaoServico configuracaoServico = null)
         {
-            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza, configuracaoServico);
-            inutCte.Assinar(configuracaoServico);
-            inutCte.ValidarShcema(configuracaoServico);
-            inutCte.SalvarXmlEmDisco(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteInutilizacao(configuracaoServico);
+            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza, configServico);
+            inutCte.Assinar(configServico);
+            inutCte.ValidarSchema(configServico);
+            inutCte.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteInutilizacao(configServico);
             var retornoXml = webService.cteInutilizacaoCT(inutCte.CriaRequestWs());
 
             var retorno = retInutCTe.LoadXml(retornoXml.OuterXml, inutCte);
-            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2), configuracaoServico);
+            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2), configServico);
 
             return retorno;
         }
 
         public async Task<retInutCTe> InutilizarAsync(ConfiguracaoServico configuracaoServico = null)
         {
-            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza, configuracaoServico);
-            inutCte.Assinar(configuracaoServico);
-            inutCte.ValidarShcema(configuracaoServico);
-            inutCte.SalvarXmlEmDisco(configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteInutilizacao(configuracaoServico);
+            var inutCte = ClassesFactory.CriaInutCTe(_configInutiliza, configServico);
+            inutCte.Assinar(configServico);
+            inutCte.ValidarSchema(configServico);
+            inutCte.SalvarXmlEmDisco(configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteInutilizacao(configServico);
             var retornoXml = await webService.cteInutilizacaoCTAsync(inutCte.CriaRequestWs());
 
             var retorno = retInutCTe.LoadXml(retornoXml.OuterXml, inutCte);
-            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2), configuracaoServico);
+            retorno.SalvarXmlEmDisco(inutCte.infInut.Id.Substring(2), configServico);
 
             return retorno;
         }

--- a/CTe.Servicos/Recepcao/ServicoCTeRecepcao.cs
+++ b/CTe.Servicos/Recepcao/ServicoCTeRecepcao.cs
@@ -53,32 +53,36 @@ namespace CTe.Servicos.Recepcao
 
         public retEnviCte CTeRecepcao(int lote, List<CTeEletronico> cteEletronicosList, ConfiguracaoServico configuracaoServico = null)
         {
-            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteRecepcao(configuracaoServico);
+            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList, configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteRecepcao(configServico);
 
             OnAntesDeEnviar(enviCte);
 
-            var retornoXml = webService.cteRecepcaoLote(enviCte.CriaRequestWs(configuracaoServico));
+            var retornoXml = webService.cteRecepcaoLote(enviCte.CriaRequestWs(configServico));
 
             var retorno = retEnviCte.LoadXml(retornoXml.OuterXml, enviCte);
-            retorno.SalvarXmlEmDisco(configuracaoServico);
+            retorno.SalvarXmlEmDisco(configServico);
 
             return retorno;
         }
 
         public async Task<retEnviCte> CTeRecepcaoAsync(int lote, List<CTeEletronico> cteEletronicosList, ConfiguracaoServico configuracaoServico = null)
         {
-            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList, configuracaoServico);
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var webService = WsdlFactory.CriaWsdlCteRecepcao(configuracaoServico);
+            var enviCte = PreparaEnvioCTe(lote, cteEletronicosList, configServico);
+
+            var webService = WsdlFactory.CriaWsdlCteRecepcao(configServico);
 
             OnAntesDeEnviar(enviCte);
 
-            var retornoXml = await webService.cteRecepcaoLoteAsync(enviCte.CriaRequestWs(configuracaoServico));
+            var retornoXml = await webService.cteRecepcaoLoteAsync(enviCte.CriaRequestWs(configServico));
 
             var retorno = retEnviCte.LoadXml(retornoXml.OuterXml, enviCte);
-            retorno.SalvarXmlEmDisco(configuracaoServico);
+            retorno.SalvarXmlEmDisco(configServico);
 
             return retorno;
         }
@@ -110,14 +114,14 @@ namespace CTe.Servicos.Recepcao
             cte.ValidaSchema(instanciaConfiguracao);
             cte.SalvarXmlEmDisco(instanciaConfiguracao);
 
-            var webService = WsdlFactory.CriaWsdlCteRecepcaoSincronoV4(configuracaoServico);
+            var webService = WsdlFactory.CriaWsdlCteRecepcaoSincronoV4(instanciaConfiguracao);
 
             //OnAntesDeEnviar(enviCte);
 
-            var retornoXml = webService.CTeRecepcaoSincV4(cte.CriaRequestWs(configuracaoServico));
+            var retornoXml = webService.CTeRecepcaoSincV4(cte.CriaRequestWs(instanciaConfiguracao));
 
             var retorno = retCTe.LoadXml(retornoXml.OuterXml, cte);
-            retorno.SalvarXmlEmDisco(cte.Chave(), configuracaoServico);
+            retorno.SalvarXmlEmDisco(cte.Chave(), instanciaConfiguracao);
 
             return retorno;
         }

--- a/CTe.Utils/CTe/ExtCTe.cs
+++ b/CTe.Utils/CTe/ExtCTe.cs
@@ -61,7 +61,7 @@ namespace CTe.Utils.CTe
         /// <returns>Retorna uma NFe carregada com os dados do XML</returns>
         public static CteEletronica CarregarDeArquivoXml(this CteEletronica cte, string arquivoXml)
         {
-            var s = FuncoesXml.ObterNodeDeArquivoXml(typeof (CteEletronica).Name, arquivoXml);
+            var s = FuncoesXml.ObterNodeDeArquivoXml(typeof(CteEletronica).Name, arquivoXml);
             return FuncoesXml.XmlStringParaClasse<CteEletronica>(s);
         }
 
@@ -83,7 +83,7 @@ namespace CTe.Utils.CTe
         /// <returns>Retorna um objeto do tipo CTe</returns>
         public static CteEletronica CarregarDeXmlString(this CteEletronica cte, string xmlString)
         {
-            var s = FuncoesXml.ObterNodeDeStringXml(typeof (CteEletronica).Name, xmlString);
+            var s = FuncoesXml.ObterNodeDeStringXml(typeof(CteEletronica).Name, xmlString);
             return FuncoesXml.XmlStringParaClasse<CteEletronica>(s);
         }
 
@@ -100,6 +100,7 @@ namespace CTe.Utils.CTe
             var xmlValidacao = cte.ObterXmlString();
 
             var servicoInstancia = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             if (!servicoInstancia.IsValidaSchemas)
                 return;
 
@@ -120,7 +121,7 @@ namespace CTe.Utils.CTe
                                                         "versão 2.00 é 3.00");
             }
 
-            if (cte.infCte.ide.tpCTe != tpCTe.Anulacao  && cte.infCte.ide.tpCTe != tpCTe.Complemento) // Ct-e do Tipo Anulação/Complemento não tem Informações do Modal
+            if (cte.infCte.ide.tpCTe != tpCTe.Anulacao && cte.infCte.ide.tpCTe != tpCTe.Complemento) // Ct-e do Tipo Anulação/Complemento não tem Informações do Modal
             {
                 var xmlModal = FuncoesXml.ClasseParaXmlString(cte.infCte.infCTeNorm.infModal);
 
@@ -291,7 +292,7 @@ namespace CTe.Utils.CTe
             qrCode.Append("&");
             qrCode.Append("tpAmb=").Append((int)cte.infCte.ide.tpAmb);
 
-            if (cte.infCte.ide.tpEmis != tpEmis.teNormal 
+            if (cte.infCte.ide.tpEmis != tpEmis.teNormal
                 && cte.infCte.ide.tpEmis != tpEmis.teSVCRS
                 && cte.infCte.ide.tpEmis != tpEmis.teSVCSP
                 )

--- a/CTe.Utils/CTe/ExtEnvCte.cs
+++ b/CTe.Utils/CTe/ExtEnvCte.cs
@@ -47,16 +47,18 @@ namespace CTe.Utils.CTe
     {
         public static void ValidaSchema(this enviCTe enviCTe, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             var xmlValidacao = enviCTe.ObterXmlString();
 
             switch (enviCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "enviCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "enviCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve400:
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "enviCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "enviCTe_v3.00.xsd", configServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -93,7 +95,7 @@ namespace CTe.Utils.CTe
             var request = new XmlDocument();
 
             var xml = enviCTe.ObterXmlString();
-            
+
             var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             if (instanciaServico.cUF == Estado.PR

--- a/CTe.Utils/DistribuicaoDFe/ExtdistDFeInt.cs
+++ b/CTe.Utils/DistribuicaoDFe/ExtdistDFeInt.cs
@@ -54,16 +54,17 @@ namespace CTe.Utils.DistribuicaoDFe
 
         public static void ValidaSchema(this distDFeInt pedDistDFeInt, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             var xmlValidacao = pedDistDFeInt.ObterXmlString();
-            
 
             if (pedDistDFeInt.versao.Equals("1.00"))
             {
-                Validador.Valida(xmlValidacao, "distDFeInt_v1.00.xsd", configuracaoServico);
+                Validador.Valida(xmlValidacao, "distDFeInt_v1.00.xsd", configServico);
             }
             else if (pedDistDFeInt.versao.Equals("1.10"))
             {
-                Validador.Valida(xmlValidacao, "distDFeInt_v1.10.xsd", configuracaoServico);
+                Validador.Valida(xmlValidacao, "distDFeInt_v1.10.xsd", configServico);
             }
             else
             {

--- a/CTe.Utils/Evento/Extevento.cs
+++ b/CTe.Utils/Evento/Extevento.cs
@@ -74,18 +74,20 @@ namespace CTe.Utils.Evento
 
         public static void ValidarSchema(this eventoCTe eventoCTe, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             var xmlEvento = eventoCTe.ObterXmlString();
 
             switch (eventoCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlEvento, "eventoCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlEvento, "eventoCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlEvento, "eventoCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlEvento, "eventoCTe_v3.00.xsd", configServico);
                     break;
                 case versao.ve400:
-                    Validador.Valida(xmlEvento, "eventoCTe_v4.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlEvento, "eventoCTe_v4.00.xsd", configServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -98,22 +100,24 @@ namespace CTe.Utils.Evento
 
         private static void ValidarSchemaEventoContainer(EventoContainer container, versao versao, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             if (container.GetType() == typeof(evCancCTe))
             {
-                var evCancCTe = (evCancCTe) container;
+                var evCancCTe = (evCancCTe)container;
 
                 var xmlEventoCancelamento = evCancCTe.ObterXmlString();
 
                 switch (versao)
                 {
                     case versao.ve200:
-                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v2.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v2.00.xsd", configServico);
                         break;
                     case versao.ve300:
-                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v3.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v3.00.xsd", configServico);
                         break;
                     case versao.ve400:
-                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v4.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCancelamento, "evCancCTe_v4.00.xsd", configServico);
                         break;
                     default:
                         throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -133,13 +137,13 @@ namespace CTe.Utils.Evento
                 switch (versao)
                 {
                     case versao.ve200:
-                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v2.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v2.00.xsd", configServico);
                         break;
                     case versao.ve300:
-                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v3.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v3.00.xsd", configServico);
                         break;
                     case versao.ve400:
-                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v4.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCCe, "evCCeCTe_v4.00.xsd", configServico);
                         break;
                     default:
                         throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -157,13 +161,13 @@ namespace CTe.Utils.Evento
                 switch (versao)
                 {
                     case versao.ve200:
-                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v2.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v2.00.xsd", configServico);
                         break;
                     case versao.ve300:
-                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v3.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v3.00.xsd", configServico);
                         break;
                     case versao.ve400:
-                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v4.00.xsd", configuracaoServico);
+                        Validador.Valida(xmlEventoCCe, "evPrestDesacordo_v4.00.xsd", configServico);
                         break;
                     default:
                         throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +

--- a/CTe.Utils/Extencoes/ExtConsReciCTe.cs
+++ b/CTe.Utils/Extencoes/ExtConsReciCTe.cs
@@ -45,15 +45,16 @@ namespace CTe.Utils.Extencoes
     {
         public static void ValidarSchema(this consReciCTe consReciCTe, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var xmlValidacao = consReciCTe.ObterXmlString();
 
             switch (consReciCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consReciCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consReciCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consReciCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consReciCTe_v3.00.xsd", configServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +

--- a/CTe.Utils/Extencoes/ExtconsSitCTe.cs
+++ b/CTe.Utils/Extencoes/ExtconsSitCTe.cs
@@ -46,20 +46,23 @@ namespace CTe.Utils.Extencoes
 
         public static void ValidarSchema(this consSitCTe consSitCTe, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             var xmlValidacao = consSitCTe.ObterXmlString();
 
             switch (consSitCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consSitCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consSitCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consSitCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consSitCTe_v3.00.xsd", configServico);
                     break;
                 case versao.ve400:
-                    Validador.Valida(xmlValidacao, "consSitCTe_v4.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consSitCTe_v4.00.xsd", configServico);
                     break;
-                default: throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
+                default:
+                    throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
                                                         "a versão está inválida, somente é permitido " +
                                                         "versão 2.00 é 3.00");
             }

--- a/CTe.Utils/Extencoes/ExtconsStatServCte.cs
+++ b/CTe.Utils/Extencoes/ExtconsStatServCte.cs
@@ -45,18 +45,20 @@ namespace CTe.Utils.Extencoes
     {
         public static void ValidarSchema(this consStatServCte consStatServCte, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             var xmlValidacao = consStatServCte.ObterXmlString();
 
             switch (consStatServCte.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v3.00.xsd", configServico);
                     break;
                 case versao.ve400:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v4.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v4.00.xsd", configServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -82,8 +84,8 @@ namespace CTe.Utils.Extencoes
             if (instanciaServico.NaoSalvarXml()) return;
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
-            
-            var arquivoSalvar = Path.Combine(caminhoXml,  DateTime.Now.ParaDataHoraString() + "-ped-sta.xml");
+
+            var arquivoSalvar = Path.Combine(caminhoXml, DateTime.Now.ParaDataHoraString() + "-ped-sta.xml");
 
             FuncoesXml.ClasseParaArquivoXml(statuServCte, arquivoSalvar);
         }
@@ -101,18 +103,20 @@ namespace CTe.Utils.Extencoes
     {
         public static void ValidarSchema(this consStatServCTe consStatServCte, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
             var xmlValidacao = consStatServCte.ObterXmlString();
 
             switch (consStatServCte.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v3.00.xsd", configServico);
                     break;
                 case versao.ve400:
-                    Validador.Valida(xmlValidacao, "consStatServCTe_v4.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "consStatServCTe_v4.00.xsd", configServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +

--- a/CTe.Utils/Extencoes/ExtinutCTe.cs
+++ b/CTe.Utils/Extencoes/ExtinutCTe.cs
@@ -63,18 +63,19 @@ namespace CTe.Utils.Extencoes
             return FuncoesXml.ClasseParaXmlString(pedInutilizacao);
         }
 
-        public static void ValidarShcema(this inutCTe inutCTe, ConfiguracaoServico configuracaoServico = null)
+        public static void ValidarSchema(this inutCTe inutCTe, ConfiguracaoServico configuracaoServico = null)
         {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
             var xmlValidacao = inutCTe.ObterXmlString();
 
             switch (inutCTe.versao)
             {
                 case versao.ve200:
-                    Validador.Valida(xmlValidacao, "inutCTe_v2.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "inutCTe_v2.00.xsd", configServico);
                     break;
                 case versao.ve300:
-                    Validador.Valida(xmlValidacao, "inutCTe_v3.00.xsd", configuracaoServico);
+                    Validador.Valida(xmlValidacao, "inutCTe_v3.00.xsd", configServico);
                     break;
                 default:
                     throw new InvalidOperationException("Nos achamos um erro na hora de validar o schema, " +
@@ -91,7 +92,7 @@ namespace CTe.Utils.Extencoes
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
 
-            var arquivoSalvar = Path.Combine(caminhoXml, inutCTe.infInut.Id+ "-ped-inu.xml");
+            var arquivoSalvar = Path.Combine(caminhoXml, inutCTe.infInut.Id + "-ped-inu.xml");
 
             FuncoesXml.ClasseParaArquivoXml(inutCTe, arquivoSalvar);
         }

--- a/CTe.Utils/Inutilizacao/ExtretInutCTe.cs
+++ b/CTe.Utils/Inutilizacao/ExtretInutCTe.cs
@@ -60,8 +60,6 @@ namespace CTe.Utils.Inutilizacao
         {
             return FuncoesXml.ClasseParaXmlString(retInutCTe);
         }
-
-        
         public static void SalvarXmlEmDisco(this retInutCTe retInutCTe, string chaveNome, ConfiguracaoServico configuracaoServico = null)
         {
             var instanciaServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
@@ -69,11 +67,10 @@ namespace CTe.Utils.Inutilizacao
             if (instanciaServico.NaoSalvarXml()) return;
 
             var caminhoXml = instanciaServico.DiretorioSalvarXml;
-            
+
             var arquivoSalvar = Path.Combine(caminhoXml, chaveNome + "-inu.xml");
 
             FuncoesXml.ClasseParaArquivoXml(retInutCTe, arquivoSalvar);
         }
-
     }
 }

--- a/CTe.Utils/Validacao/Validador.cs
+++ b/CTe.Utils/Validacao/Validador.cs
@@ -60,7 +60,7 @@ namespace CTe.Utils.Validacao
             schemas.XmlResolver = new XmlUrlResolver();
 
             cfg.Schemas = schemas;
-            // Quando carregar o eschema, especificar o namespace que ele valida
+            // Quando carregar o schema, especificar o namespace que ele valida
             // e a localização do arquivo 
             schemas.Add(null, arquivoSchema);
             // Especifica o tratamento de evento para os erros de validacao


### PR DESCRIPTION
Em alguns casos, alguns processos como cancelamento da CTe estava gerando exception devido a isto, verifiquei que tinham mais lugares necessitando de tratamento.

Procurei garantir que instancia do serviço sempre seja usada corretamente, como é nulavel o parâmetro ConfiguracaoServico configuracaoServico em alguns lugares estava chegando nulo, dependendo do fluxo da CTe utilizado, fiz um tratamento padrão em todos lugares que poderia acontecer, apesar de em alguns métodos de validação que são usados em vários lugares já tratar de instanciar novamente o serviço, muitos lugares não instanciava, gerando exception em alguns métodos. Acredito que tenha tratado todos lugares onde é nulavel o parâmetro configuracaoServico.