### PR TITLE
FastReport.Utils.CompilerException: (316,13): Error CS1717: Assignment made to same variable; did you mean to assign something else?

### DIFF
--- a/NFe.Danfe.Base/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Base/NFe/NFeRetrato.frx
@@ -314,8 +314,6 @@ namespace FastReport
             valor = &quot;(&quot; +valor.Substring(0,2) + &quot;) &quot; + valor.Substring(2,4) + &quot;-&quot; + valor.Substring(6,4);
           else if (valor.Length == 11)
             valor = &quot;(&quot; +valor.Substring(0,2) + &quot;) &quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);     
-          else 
-            valor = valor;
           break;
         
         case 'd': //cpf / cnpj


### PR DESCRIPTION
Este ajuste ajuda na correção de um possível bug na geração do relatório FastReport utilizando o seguinte ambiente:

.Net Framwork 4.8
FastReport.Compat 2024.1.0
NFe.Danfe.Base.dll ( net462 )
NFe.Danfe.OpenFast.dll ( net462 )

StackTrace:

FastReport.Utils.CompilerException: (316,13): Error CS1717: Assignment made to same variable; did you mean to assign something else?

  at FastReport.Code.AssemblyDescriptor.InternalCompile () [0x00085] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Code.AssemblyDescriptor.Compile () [0x00020] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Report.Compile () [0x00045] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Report.Prepare (System.Boolean append) [0x00037] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Report.Prepare () [0x00000] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at (wrapper remoting-invoke-with-check) FastReport.Report.Prepare()
  at NFe.Danfe.OpenFast.DanfeOpenFastBase.ExportarPdf (System.String arquivo) [0x00007] in <14866dd957784011bd921d9d7a301c62>:0 
