### PR TITLE
FastReport.Utils.CompilerException: (Text34): Error CS0105: The using directive for `NFe.Classes.Informacoes.Identificacao.Tipos' appeared previously in this namespace

### DIFF
--- a/NFe.Danfe.Base/NFe/NFeSimplificado.frx
+++ b/NFe.Danfe.Base/NFe/NFeSimplificado.frx
@@ -16,7 +16,6 @@ using FastReport.Dialog;
 using FastReport.Barcode;
 using FastReport.Table;
 using FastReport.Utils;
-using NFe.Classes.Informacoes.Identificacao.Tipos;
 using NFe.Classes.Informacoes.Detalhe.Tributacao;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
 using NFe.Classes.Informacoes.Detalhe.Tributacao.Federal.Tipos;


### PR DESCRIPTION
Este ajuste ajuda na correção de um possível bug na geração do relatório FastReport utilizando o seguinte ambiente:

.Net Framwork 4.8
FastReport.Compat 2024.1.0
NFe.Danfe.Base.dll ( net462 )
NFe.Danfe.OpenFast.dll ( net462 )

StackTrace:

FastReport.Utils.CompilerException: (Text34): Error CS0105: The using directive for `NFe.Classes.Informacoes.Identificacao.Tipos' appeared previously in this namespace

  at FastReport.Code.AssemblyDescriptor.InternalCompile () [0x00085] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Code.AssemblyDescriptor.Compile () [0x00020] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Report.Compile () [0x00045] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Report.Prepare (System.Boolean append) [0x00037] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at FastReport.Report.Prepare () [0x00000] in <1f828f5a823142149547b1ffc3d3e36f>:0 
  at (wrapper remoting-invoke-with-check) FastReport.Report.Prepare()
  at NFe.Danfe.OpenFast.DanfeOpenFastBase.ExportarPdf (System.String arquivo) [0x00007] in <14866dd957784011bd921d9d7a301c62>:0 
