### PR TITLE
fix:Ajuste nos níveis de serialização do grupo de cana

### DIFF
--- a/NFe.Classes/Informacoes/Cana/cana.cs
+++ b/NFe.Classes/Informacoes/Cana/cana.cs
@@ -37,6 +37,13 @@ namespace NFe.Classes.Informacoes.Cana
 {
     public class cana
     {
+        private decimal _qTotMes;
+        private decimal _qTotAnt;
+        private decimal _qTotGer;
+        private decimal _vFor;
+        private decimal _vTotDed;
+        private decimal _vLiqFor;
+
         /// <summary>
         ///     ZC02 - Identificação da safra
         /// </summary>
@@ -54,9 +61,63 @@ namespace NFe.Classes.Informacoes.Cana
         public List<forDia> forDia { get; set; }
 
         /// <summary>
+        ///     ZC07 - Quantidade Total do Mês
+        /// </summary>
+        public decimal qTotMes
+        {
+            get { return _qTotMes; }
+            set { _qTotMes = value.Arredondar(10); }
+        }
+
+        /// <summary>
+        ///     ZC08 - Quantidade Total Anterior
+        /// </summary>
+        public decimal qTotAnt
+        {
+            get { return _qTotAnt; }
+            set { _qTotAnt = value.Arredondar(10); }
+        }
+
+        /// <summary>
+        ///     ZC09 - Quantidade Total Geral
+        /// </summary>
+        public decimal qTotGer
+        {
+            get { return _qTotGer; }
+            set { _qTotGer = value.Arredondar(10); }
+        }
+
+        /// <summary>
         ///     ZC10 - Grupo Deduções – Taxas e Contribuições
         /// </summary>
         [XmlElement("deduc")]
         public List<deduc> deduc { get; set; }
+
+        /// <summary>
+        ///     ZC13 - Valor dos Fornecimentos
+        /// </summary>
+        public decimal vFor
+        {
+            get { return _vFor; }
+            set { _vFor = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        ///     ZC14 - Valor Total da Dedução
+        /// </summary>
+        public decimal vTotDed
+        {
+            get { return _vTotDed; }
+            set { _vTotDed = value.Arredondar(2); }
+        }
+
+        /// <summary>
+        ///     ZC15 - Valor Líquido dos Fornecimentos
+        /// </summary>
+        public decimal vLiqFor
+        {
+            get { return _vLiqFor; }
+            set { _vLiqFor = value.Arredondar(2); }
+        }
     }
 }

--- a/NFe.Classes/Informacoes/Cana/deduc.cs
+++ b/NFe.Classes/Informacoes/Cana/deduc.cs
@@ -35,9 +35,6 @@ namespace NFe.Classes.Informacoes.Cana
     public class deduc
     {
         private decimal _vDed;
-        private decimal _vFor;
-        private decimal _vTotDed;
-        private decimal _vLiqFor;
 
         /// <summary>
         ///     ZC11 - Descrição da Dedução
@@ -51,33 +48,6 @@ namespace NFe.Classes.Informacoes.Cana
         {
             get { return _vDed; }
             set { _vDed = value.Arredondar(2); }
-        }
-
-        /// <summary>
-        ///     ZC13 - Valor dos Fornecimentos
-        /// </summary>
-        public decimal vFor
-        {
-            get { return _vFor; }
-            set { _vFor = value.Arredondar(2); }
-        }
-
-        /// <summary>
-        ///     ZC14 - Valor Total da Dedução
-        /// </summary>
-        public decimal vTotDed
-        {
-            get { return _vTotDed; }
-            set { _vTotDed = value.Arredondar(2); }
-        }
-
-        /// <summary>
-        ///     ZC15 - Valor Líquido dos Fornecimentos
-        /// </summary>
-        public decimal vLiqFor
-        {
-            get { return _vLiqFor; }
-            set { _vLiqFor = value.Arredondar(2); }
         }
     }
 }

--- a/NFe.Classes/Informacoes/Cana/forDia.cs
+++ b/NFe.Classes/Informacoes/Cana/forDia.cs
@@ -37,9 +37,6 @@ namespace NFe.Classes.Informacoes.Cana
     public class forDia
     {
         private decimal _qtde;
-        private decimal _qTotMes;
-        private decimal _qTotAnt;
-        private decimal _qTotGer;
 
         /// <summary>
         ///     ZC05 - Dia
@@ -54,33 +51,6 @@ namespace NFe.Classes.Informacoes.Cana
         {
             get { return _qtde; }
             set { _qtde = value.Arredondar(10); }
-        }
-
-        /// <summary>
-        ///     ZC07 - Quantidade Total do Mês
-        /// </summary>
-        public decimal qTotMes
-        {
-            get { return _qTotMes; }
-            set { _qTotMes = value.Arredondar(10); }
-        }
-
-        /// <summary>
-        ///     ZC08 - Quantidade Total Anterior
-        /// </summary>
-        public decimal qTotAnt
-        {
-            get { return _qTotAnt; }
-            set { _qTotAnt = value.Arredondar(10); }
-        }
-
-        /// <summary>
-        ///     ZC09 - Quantidade Total Geral
-        /// </summary>
-        public decimal qTotGer
-        {
-            get { return _qTotGer; }
-            set { _qTotGer = value.Arredondar(10); }
         }
     }
 }


### PR DESCRIPTION
Ajustado as propriedades de totalizadores que deveriam ser como pai o nó ZC01-cana, e estavam embaixo dos grupos forDia e deduc.