### PR TITLE
Adicionado suporte ao CRT MEI para DANFE e exemplos appteste

### DIFF
--- a/NFe.AppTeste.NetCore/Program.cs
+++ b/NFe.AppTeste.NetCore/Program.cs
@@ -698,7 +698,7 @@ namespace NFe.AppTeste.NetCore
 
                         //Caso você resolva utilizar método ObterIcmsBasico(), comente esta proxima linha
                         TipoICMS =
-                            crt == CRT.SimplesNacional
+                            crt == CRT.SimplesNacional || crt == CRT.SimplesNacionalMei
                                 ? InformarCSOSN(Csosnicms.Csosn102)
                                 : InformarICMS(Csticms.Cst00, VersaoServico.Versao310)
                     },

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1388,7 +1388,7 @@ namespace NFe.AppTeste
 
                         //Caso você resolva utilizar método ObterIcmsBasico(), comente esta proxima linha
                         TipoICMS =
-                            crt == CRT.SimplesNacional
+                            crt == CRT.SimplesNacional || crt == CRT.SimplesNacionalMei
                                 ? InformarCSOSN(Csosnicms.Csosn102)
                                 : InformarICMS(Csticms.Cst00, VersaoServico.Versao310)
                     },

--- a/NFe.Danfe.Base/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Base/NFe/NFeRetrato.frx
@@ -198,7 +198,7 @@ namespace FastReport
 	  if (icmsBasico != null)
 	  {
 	      var orig = icmsBasico.GetIcmsOrig();
-	      if ((CRT)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional)
+	      if ((CRT)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional || ((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacionalMei)
 	      {
              if (icmsBasico.GetIcmsCst().CsticmsParaString() == &quot;02&quot; || icmsBasico.GetIcmsCst().CsticmsParaString() == &quot;15&quot; ||
                  icmsBasico.GetIcmsCst().CsticmsParaString() == &quot;53&quot; || icmsBasico.GetIcmsCst().CsticmsParaString() == &quot;61&quot;)
@@ -463,8 +463,9 @@ namespace FastReport
     private void DadosProdutosHeader_BeforePrint(object sender, EventArgs e)
     {
       
-      if (((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional) {
-        Memo119.Text = &quot;O/CSOSN&quot;;
+      if (((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional || ((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacionalMei) 
+	  {
+	    Memo119.Text = &quot;O/CSOSN&quot;;
       }
       
       _Tamanho = 0;

--- a/NFe.Danfe.Base/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Base/NFe/NFeRetrato.frx
@@ -463,8 +463,7 @@ namespace FastReport
     private void DadosProdutosHeader_BeforePrint(object sender, EventArgs e)
     {
       
-      if (((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional || ((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacionalMei) 
-	  {
+      if (((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional || ((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacionalMei) {
 	    Memo119.Text = &quot;O/CSOSN&quot;;
       }
       


### PR DESCRIPTION
**DANFE CSOSN 500 CRT = 4 (MEI)**

**Antes:**
![image](https://github.com/user-attachments/assets/e9f44e00-9fd2-46cd-97e1-ca70bff9b0ca)
**Depois:**
![image](https://github.com/user-attachments/assets/116459f4-b36c-4328-a10a-977bf8cf63fa)

