### PR TITLE
Transformada classe MDFeConfiguracao de static para singleton

### DIFF
--- a/MDFe.AppTeste/MDFeTesteModel.cs
+++ b/MDFe.AppTeste/MDFeTesteModel.cs
@@ -579,7 +579,7 @@ namespace MDFe.AppTeste
             #endregion dados emitente (emit)
 
             #region modal
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao100)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao100)
             {
                 mdfe.InfMDFe.InfModal.Modal = new MDFeRodo
                 {
@@ -607,7 +607,7 @@ namespace MDFe.AppTeste
             }
 
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.InfModal.Modal = new MDFeRodo
                 {
@@ -689,7 +689,7 @@ namespace MDFe.AppTeste
             };
 
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.InfDoc.InfMunDescarga[0].InfCTe[0].Peri = new List<MDFePeri>
                 {
@@ -705,7 +705,7 @@ namespace MDFe.AppTeste
 
             #region seg
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.Seg = new List<MDFeSeg>();
 
@@ -733,7 +733,7 @@ namespace MDFe.AppTeste
 
             #region Produto Predominante
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.prodPred = new prodPred
                 {
@@ -865,7 +865,7 @@ namespace MDFe.AppTeste
             #endregion dados emitente (emit)
 
             #region modal
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao100)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao100)
             {
                 mdfe.InfMDFe.InfModal.VersaoModal = MDFeVersaoModal.Versao100;
                 mdfe.InfMDFe.InfModal.Modal = new MDFeRodo
@@ -894,7 +894,7 @@ namespace MDFe.AppTeste
             }
 
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.InfModal.VersaoModal = MDFeVersaoModal.Versao300;
                 mdfe.InfMDFe.InfModal.Modal = new MDFeRodo
@@ -978,7 +978,7 @@ namespace MDFe.AppTeste
             };
 
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.InfDoc.InfMunDescarga[0].InfCTe[0].Peri = new List<MDFePeri>
                 {
@@ -994,7 +994,7 @@ namespace MDFe.AppTeste
 
             #region seg
 
-            if (MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
                 mdfe.InfMDFe.Seg = new List<MDFeSeg>();
 
@@ -1346,17 +1346,17 @@ namespace MDFe.AppTeste
                 ManterDadosEmCache = config.CertificadoDigital.ManterEmCache,
             };
 
-            MDFeConfiguracao.ConfiguracaoCertificado = configuracaoCertificado;
-            MDFeConfiguracao.CaminhoSchemas = config.ConfigWebService.CaminhoSchemas;
-            MDFeConfiguracao.CaminhoSalvarXml = config.DiretorioSalvarXml;
-            MDFeConfiguracao.IsSalvarXml = config.IsSalvarXml;
+            MDFeConfiguracao.Instancia.ConfiguracaoCertificado = configuracaoCertificado;
+            MDFeConfiguracao.Instancia.CaminhoSchemas = config.ConfigWebService.CaminhoSchemas;
+            MDFeConfiguracao.Instancia.CaminhoSalvarXml = config.DiretorioSalvarXml;
+            MDFeConfiguracao.Instancia.IsSalvarXml = config.IsSalvarXml;
 
-            MDFeConfiguracao.VersaoWebService.VersaoLayout = config.ConfigWebService.VersaoLayout;
+            MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout = config.ConfigWebService.VersaoLayout;
 
-            MDFeConfiguracao.VersaoWebService.TipoAmbiente = config.ConfigWebService.Ambiente;
-            MDFeConfiguracao.VersaoWebService.UfEmitente = config.ConfigWebService.UfEmitente;
-            MDFeConfiguracao.VersaoWebService.TimeOut = config.ConfigWebService.TimeOut;
-            MDFeConfiguracao.IsAdicionaQrCode = true;
+            MDFeConfiguracao.Instancia.VersaoWebService.TipoAmbiente = config.ConfigWebService.Ambiente;
+            MDFeConfiguracao.Instancia.VersaoWebService.UfEmitente = config.ConfigWebService.UfEmitente;
+            MDFeConfiguracao.Instancia.VersaoWebService.TimeOut = config.ConfigWebService.TimeOut;
+            MDFeConfiguracao.Instancia.IsAdicionaQrCode = true;
         }
 
         protected virtual void OnSucessoSync(RetornoEEnvio e)

--- a/MDFe.Classes/Extensoes/ExtMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFe.cs
@@ -17,19 +17,20 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFe
     {
-        public static MDFEletronico Valida(this MDFEletronico mdfe)
+        public static MDFEletronico Valida(this MDFEletronico mdfe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             if (mdfe == null) throw new ArgumentException("Erro de assinatura, MDFe esta null");
 
             var xmlMdfe = FuncoesXml.ClasseParaXmlString(mdfe);
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlMdfe, "mdfe_v1.00.xsd");
+                    Validador.Valida(xmlMdfe, "mdfe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlMdfe, "mdfe_v3.00.xsd");
+                    Validador.Valida(xmlMdfe, "mdfe_v3.00.xsd", config);
                     break;
             }
 
@@ -39,52 +40,52 @@ namespace MDFe.Classes.Extencoes
 
             if (tipoModal == typeof (MDFeRodo))
             {
-                switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+                switch (config.VersaoWebService.VersaoLayout)
                 {
                     case VersaoServico.Versao100:
-                        Validador.Valida(xmlModal, "mdfeModalRodoviario_v1.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalRodoviario_v1.00.xsd", config);
                         break;
                     case VersaoServico.Versao300:
-                        Validador.Valida(xmlModal, "mdfeModalRodoviario_v3.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalRodoviario_v3.00.xsd", config);
                         break;
                 }
             }
 
             if (tipoModal == typeof (MDFeAereo))
             {
-                switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+                switch (config.VersaoWebService.VersaoLayout)
                 {
                     case VersaoServico.Versao100:
-                        Validador.Valida(xmlModal, "mdfeModalAereo_v1.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalAereo_v1.00.xsd", config);
                         break;
                     case VersaoServico.Versao300:
-                        Validador.Valida(xmlModal, "mdfeModalAereo_v3.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalAereo_v3.00.xsd", config);
                         break;
                 }
             }
 
             if (tipoModal == typeof (MDFeAquav))
             {
-                switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+                switch (config.VersaoWebService.VersaoLayout)
                 {
                     case VersaoServico.Versao100:
-                        Validador.Valida(xmlModal, "mdfeModalAquaviario_v1.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalAquaviario_v1.00.xsd", config);
                         break;
                     case VersaoServico.Versao300:
-                        Validador.Valida(xmlModal, "mdfeModalAquaviario_v3.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalAquaviario_v3.00.xsd", config);
                         break;
                 }
             }
 
             if (tipoModal == typeof (MDFeFerrov))
             {
-                switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+                switch (config.VersaoWebService.VersaoLayout)
                 {
                     case VersaoServico.Versao100:
-                        Validador.Valida(xmlModal, "mdfeModalFerroviario_v1.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalFerroviario_v1.00.xsd", config);
                         break;
                     case VersaoServico.Versao300:
-                        Validador.Valida(xmlModal, "mdfeModalFerroviario_v3.00.xsd");
+                        Validador.Valida(xmlModal, "mdfeModalFerroviario_v3.00.xsd", config);
                         break;
                 }
             }
@@ -92,10 +93,11 @@ namespace MDFe.Classes.Extencoes
             return mdfe;
         }
 
-        public static MDFEletronico Assina(this MDFEletronico mdfe, EventHandler<string> eventHandlerChaveMdfe = null, object quemInvocouEventoChaveMDFe = null)
+        public static MDFEletronico Assina(this MDFEletronico mdfe, EventHandler<string> eventHandlerChaveMdfe = null, object quemInvocouEventoChaveMDFe = null, MDFeConfiguracao cfgMdfe = null)
         {
             if(mdfe == null) throw new ArgumentException("Erro de assinatura, MDFe esta null");
 
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var modeloDocumentoFiscal = mdfe.InfMDFe.Ide.Mod;
             var tipoEmissao = (int) mdfe.InfMDFe.Ide.TpEmis;
             var codigoNumerico = mdfe.InfMDFe.Ide.CMDF;
@@ -118,10 +120,10 @@ namespace MDFe.Classes.Extencoes
             if (eventHandlerChaveMdfe != null)
                 eventHandlerChaveMdfe.Invoke(quemInvocouEventoChaveMDFe, dadosChave.Chave);
 
-            mdfe.InfMDFe.Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout;
+            mdfe.InfMDFe.Versao = config.VersaoWebService.VersaoLayout;
             mdfe.InfMDFe.Ide.CDV = dadosChave.DigitoVerificador;
 
-            var assinatura = AssinaturaDigital.Assina(mdfe, mdfe.InfMDFe.Id, MDFeConfiguracao.X509Certificate2);
+            var assinatura = AssinaturaDigital.Assina(mdfe, mdfe.InfMDFe.Id, config.X509Certificate2);
 
             mdfe.Signature = assinatura;
 
@@ -133,12 +135,13 @@ namespace MDFe.Classes.Extencoes
             return FuncoesXml.ClasseParaXmlString(mdfe);
         }
 
-        public static void SalvarXmlEmDisco(this MDFEletronico mdfe, string nomeArquivo = null)
+        public static void SalvarXmlEmDisco(this MDFEletronico mdfe, string nomeArquivo = null, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
             if (string.IsNullOrEmpty(nomeArquivo))
-                nomeArquivo = Path.Combine(MDFeConfiguracao.CaminhoSalvarXml, mdfe.Chave() + "-mdfe.xml");
+                nomeArquivo = Path.Combine(config.CaminhoSalvarXml, mdfe.Chave() + "-mdfe.xml");
 
             FuncoesXml.ClasseParaArquivoXml(mdfe, nomeArquivo);
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeConsReciMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeConsReciMDFe.cs
@@ -10,17 +10,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeConsReciMDFe
     {
-        public static void ValidaSchema(this MDFeConsReciMDFe consReciMDFe)
+        public static void ValidaSchema(this MDFeConsReciMDFe consReciMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlValidacao = consReciMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlValidacao, "consReciMDFe_v1.00.xsd");
+                    Validador.Valida(xmlValidacao, "consReciMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlValidacao, "consReciMDFe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "consReciMDFe_v3.00.xsd", config);
                     break;
             }
         }
@@ -38,11 +39,12 @@ namespace MDFe.Classes.Extencoes
             return request;
         }
 
-        public static void SalvarXmlEmDisco(this MDFeConsReciMDFe consReciMDFe)
+        public static void SalvarXmlEmDisco(this MDFeConsReciMDFe consReciMDFe, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, consReciMDFe.NRec + "-ped-rec.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeConsSitMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeConsSitMDFe.cs
@@ -10,17 +10,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeConsSitMDFe
     {
-        public static void ValidarSchema(this MDFeConsSitMDFe consSitMdfe)
+        public static void ValidarSchema(this MDFeConsSitMDFe consSitMdfe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlEnvio = consSitMdfe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlEnvio, "consSitMDFe_v1.00.xsd");
+                    Validador.Valida(xmlEnvio, "consSitMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlEnvio, "consSitMDFe_v3.00.xsd");
+                    Validador.Valida(xmlEnvio, "consSitMDFe_v3.00.xsd", config);
                     break;
             }
         }
@@ -38,11 +39,12 @@ namespace MDFe.Classes.Extencoes
             return request;
         }
 
-        public static void SalvarXmlEmDisco(this MDFeConsSitMDFe consSitMdfe)
+        public static void SalvarXmlEmDisco(this MDFeConsSitMDFe consSitMdfe, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, consSitMdfe.ChMDFe + "-ped-sit.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeConsStatServMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeConsStatServMDFe.cs
@@ -10,17 +10,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeConsStatServMDFe
     {
-        public static void ValidarSchema(this MDFeConsStatServMDFe consStatServMDFe)
+        public static void ValidarSchema(this MDFeConsStatServMDFe consStatServMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlValidacao = consStatServMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlValidacao, "consStatServMDFe_v1.00.xsd");
+                    Validador.Valida(xmlValidacao, "consStatServMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlValidacao, "consStatServMDFe_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "consStatServMDFe_v3.00.xsd", config);
                     break;
             }
         }
@@ -38,11 +39,12 @@ namespace MDFe.Classes.Extencoes
             return request;
         }
 
-        public static void SalvarXmlEmDisco(this MDFeConsStatServMDFe consStatServMdFe)
+        public static void SalvarXmlEmDisco(this MDFeConsStatServMDFe consStatServMdFe, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, "-pedido-status-servico.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeCosMDFeNaoEnc.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeCosMDFeNaoEnc.cs
@@ -15,17 +15,18 @@ namespace MDFe.Classes.Extencoes
             return FuncoesXml.ClasseParaXmlString(consMDFeNaoEnc);
         }
 
-        public static void ValidarSchema(this MDFeCosMDFeNaoEnc consMdFeNaoEnc)
+        public static void ValidarSchema(this MDFeCosMDFeNaoEnc consMdFeNaoEnc, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlValidacao = consMdFeNaoEnc.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlValidacao, "consMDFeNaoEnc_v1.00.xsd");
+                    Validador.Valida(xmlValidacao, "consMDFeNaoEnc_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlValidacao, "consMDFeNaoEnc_v3.00.xsd");
+                    Validador.Valida(xmlValidacao, "consMDFeNaoEnc_v3.00.xsd", config);
                     break;
             }
         }
@@ -38,11 +39,12 @@ namespace MDFe.Classes.Extencoes
             return request;
         }
 
-        public static void SalvarXmlEmDisco(this MDFeCosMDFeNaoEnc cosMdFeNaoEnc)
+        public static void SalvarXmlEmDisco(this MDFeCosMDFeNaoEnc cosMdFeNaoEnc, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, cosMdFeNaoEnc.CNPJ + "-ped-sit.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeEnviMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEnviMDFe.cs
@@ -11,23 +11,24 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeEnviMDFe
     {
-        public static void Valida(this MDFeEnviMDFe enviMDFe)
+        public static void Valida(this MDFeEnviMDFe enviMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             if (enviMDFe == null) throw new ArgumentException("Erro de assinatura, EnviMDFe esta null");
 
             var xmlMdfe = FuncoesXml.ClasseParaXmlString(enviMDFe);
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlMdfe, "enviMDFe_v1.00.xsd");
+                    Validador.Valida(xmlMdfe, "enviMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlMdfe, "enviMDFe_v3.00.xsd");
+                    Validador.Valida(xmlMdfe, "enviMDFe_v3.00.xsd", config);
                     break;
             }
 
-            enviMDFe.MDFe.Valida();
+            enviMDFe.MDFe.Valida(config);
         }
 
         public static XmlDocument CriaXmlRequestWs(this MDFeEnviMDFe enviMDFe)
@@ -53,17 +54,18 @@ namespace MDFe.Classes.Extencoes
             return xmlString;
         }
 
-        public static void SalvarXmlEmDisco(this MDFeEnviMDFe enviMDFe)
+        public static void SalvarXmlEmDisco(this MDFeEnviMDFe enviMDFe, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, enviMDFe.MDFe.Chave() + "-completo-mdfe.xml");
 
             FuncoesXml.ClasseParaArquivoXml(enviMDFe, arquivoSalvar);
 
-            enviMDFe.MDFe.SalvarXmlEmDisco();
+            enviMDFe.MDFe.SalvarXmlEmDisco(cfgMdfe: config);
         }
     }
 }

--- a/MDFe.Classes/Extensoes/ExtMDFeEvCancMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEvCancMDFe.cs
@@ -8,17 +8,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeEvCancMDFe
     {
-        public static void ValidaSchema(this MDFeEvCancMDFe evCancMDFe)
+        public static void ValidaSchema(this MDFeEvCancMDFe evCancMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlCancelamento = evCancMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlCancelamento, "evCancMDFe_v1.00.xsd");
+                    Validador.Valida(xmlCancelamento, "evCancMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlCancelamento, "evCancMDFe_v3.00.xsd");
+                    Validador.Valida(xmlCancelamento, "evCancMDFe_v3.00.xsd", config);
                     break;
             }
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeEvEncMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEvEncMDFe.cs
@@ -8,17 +8,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeEvEncMDFe
     {
-        public static void ValidaSchema(this MDFeEvEncMDFe evEncMDFe)
+        public static void ValidaSchema(this MDFeEvEncMDFe evEncMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlEncerramento = evEncMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlEncerramento, "evEncMDFe_v1.00.xsd");
+                    Validador.Valida(xmlEncerramento, "evEncMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlEncerramento, "evEncMDFe_v3.00.xsd");
+                    Validador.Valida(xmlEncerramento, "evEncMDFe_v3.00.xsd", config);
                     break;
             }
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeEvIncCondutorMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEvIncCondutorMDFe.cs
@@ -8,17 +8,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeEvIncCondutorMDFe
     {
-        public static void ValidaSchema(this MDFeEvIncCondutorMDFe evIncCondutorMDFe)
+        public static void ValidaSchema(this MDFeEvIncCondutorMDFe evIncCondutorMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlIncluirCondutor = evIncCondutorMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlIncluirCondutor, "evIncCondutorMDFe_v1.00.xsd");
+                    Validador.Valida(xmlIncluirCondutor, "evIncCondutorMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlIncluirCondutor, "evIncCondutorMDFe_v3.00.xsd");
+                    Validador.Valida(xmlIncluirCondutor, "evIncCondutorMDFe_v3.00.xsd", config);
                     break;
             }
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeEvIncDFeMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEvIncDFeMDFe.cs
@@ -8,14 +8,15 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeEvIncDFeMDFe
     {
-        public static void ValidaSchema(this MDFeEvIncDFeMDFe evIncDFeMDFe)
+        public static void ValidaSchema(this MDFeEvIncDFeMDFe evIncDFeMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlIncluirDFe = evIncDFeMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlIncluirDFe, "evInclusaoDFeMDFe_v3.00.xsd");
+                    Validador.Valida(xmlIncluirDFe, "evInclusaoDFeMDFe_v3.00.xsd", config);
                     break;
             }
         }

--- a/MDFe.Classes/Extensoes/ExtMDFeEventoMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeEventoMDFe.cs
@@ -12,17 +12,18 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeEventoMDFe
     {
-        public static void ValidarSchema(this MDFeEventoMDFe evento)
+        public static void ValidarSchema(this MDFeEventoMDFe evento, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var xmlValido = evento.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
-                    Validador.Valida(xmlValido, "eventoMDFe_v1.00.xsd");
+                    Validador.Valida(xmlValido, "eventoMDFe_v1.00.xsd", config);
                     break;
                 case VersaoServico.Versao300:
-                    Validador.Valida(xmlValido, "eventoMDFe_v3.00.xsd");
+                    Validador.Valida(xmlValido, "eventoMDFe_v3.00.xsd", config);
                     break;
             }
 
@@ -31,35 +32,35 @@ namespace MDFe.Classes.Extencoes
             if (tipoEvento == typeof(MDFeEvCancMDFe))
             {
                 var objetoXml = (MDFeEvCancMDFe)evento.InfEvento.DetEvento.EventoContainer;
-                objetoXml.ValidaSchema();
+                objetoXml.ValidaSchema(config);
             }
 
             if (tipoEvento == typeof(MDFeEvEncMDFe))
             {
                 var objetoXml = (MDFeEvEncMDFe)evento.InfEvento.DetEvento.EventoContainer;
 
-                objetoXml.ValidaSchema();
+                objetoXml.ValidaSchema(config);
             }
 
             if (tipoEvento == typeof(MDFeEvIncCondutorMDFe))
             {
                 var objetoXml = (MDFeEvIncCondutorMDFe)evento.InfEvento.DetEvento.EventoContainer;
 
-                objetoXml.ValidaSchema();
+                objetoXml.ValidaSchema(config);
             }
 
             if (tipoEvento == typeof(MDFeEvIncDFeMDFe))
             {
                 var objetoXml = (MDFeEvIncDFeMDFe)evento.InfEvento.DetEvento.EventoContainer;
 
-                objetoXml.ValidaSchema();
+                objetoXml.ValidaSchema(config);
             }
 
             if (tipoEvento == typeof(evPagtoOperMDFe))
             {
                 var objetoXml = (evPagtoOperMDFe)evento.InfEvento.DetEvento.EventoContainer;
 
-                objetoXml.ValidaSchema();
+                objetoXml.ValidaSchema(config);
             }
         }
 
@@ -76,17 +77,19 @@ namespace MDFe.Classes.Extencoes
             return FuncoesXml.ClasseParaXmlString(evento);
         }
 
-        public static void Assinar(this MDFeEventoMDFe evento)
+        public static void Assinar(this MDFeEventoMDFe evento, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             evento.Signature = AssinaturaDigital.Assina(evento, evento.InfEvento.Id,
-                MDFeConfiguracao.X509Certificate2);
+                config.X509Certificate2);
         }
 
-        public static void SalvarXmlEmDisco(this MDFeEventoMDFe evento, string chave)
+        public static void SalvarXmlEmDisco(this MDFeEventoMDFe evento, string chave, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, chave + "-ped-eve.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsMDFeNao.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsMDFeNao.cs
@@ -7,11 +7,12 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeRetConsMDFeNao
     {
-        public static void SalvarXmlEmDisco(this MDFeRetConsMDFeNao retConsMdFeNao, string cnpj)
+        public static void SalvarXmlEmDisco(this MDFeRetConsMDFeNao retConsMdFeNao, string cnpj, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, cnpj + "-sit.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsReciMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsReciMDFe.cs
@@ -7,11 +7,12 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeRetConsReciMDFe
     {
-        public static void SalvarXmlEmDisco(this MDFeRetConsReciMDFe consReciMdFe)
+        public static void SalvarXmlEmDisco(this MDFeRetConsReciMDFe consReciMdFe, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, consReciMdFe.NRec + "-pro-rec.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsSitMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsSitMDFe.cs
@@ -7,11 +7,12 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeRetConsSitMDFe
     {
-        public static void SalvarXmlEmDisco(this MDFeRetConsSitMDFe retConsSitMdFe, string chave)
+        public static void SalvarXmlEmDisco(this MDFeRetConsSitMDFe retConsSitMdFe, string chave, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml,  chave + "-sit.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeRetConsStatServ.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetConsStatServ.cs
@@ -7,11 +7,12 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeRetConsStatServ
     {
-        public static void SalvarXmlEmDisco(this MDFeRetConsStatServ retConsStatServ)
+        public static void SalvarXmlEmDisco(this MDFeRetConsStatServ retConsStatServ, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, "-retorno-status-servico.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeRetEnviMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetEnviMDFe.cs
@@ -7,11 +7,12 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeRetEnviMDFe
     {
-        public static void SalvarXmlEmDisco(this MDFeRetEnviMDFe retEnviMDFe)
+        public static void SalvarXmlEmDisco(this MDFeRetEnviMDFe retEnviMDFe, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, retEnviMDFe.InfRec.NRec + "-rec.xml");
 

--- a/MDFe.Classes/Extensoes/ExtMDFeRetEventoMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtMDFeRetEventoMDFe.cs
@@ -7,11 +7,12 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtMDFeRetEventoMDFe
     {
-        public static void SalvarXmlEmDisco(this MDFeRetEventoMDFe retEvento, string chave)
+        public static void SalvarXmlEmDisco(this MDFeRetEventoMDFe retEvento, string chave, MDFeConfiguracao cfgMdfe = null)
         {
-            if (MDFeConfiguracao.NaoSalvarXml()) return;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            if (config.NaoSalvarXml()) return;
 
-            var caminhoXml = MDFeConfiguracao.CaminhoSalvarXml;
+            var caminhoXml = config.CaminhoSalvarXml;
 
             var arquivoSalvar = Path.Combine(caminhoXml, chave + "-env.xml");
 

--- a/MDFe.Classes/Extensoes/ExtevPagtoOperMDFe.cs
+++ b/MDFe.Classes/Extensoes/ExtevPagtoOperMDFe.cs
@@ -8,14 +8,15 @@ namespace MDFe.Classes.Extencoes
 {
     public static class ExtevPagtoOperMDFe
     {
-        public static void ValidaSchema(this evPagtoOperMDFe evIncDFeMDFe)
+        public static void ValidaSchema(this evPagtoOperMDFe evIncDFeMDFe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var ev = evIncDFeMDFe.XmlString();
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao300:
-                    Validador.Valida(ev, "evPagtoOperMDFe_v3.00.xsd");
+                    Validador.Valida(ev, "evPagtoOperMDFe_v3.00.xsd", config);
                     break;
             }
         }

--- a/MDFe.Classes/Informacoes/Evento/MDFeInfEvento.cs
+++ b/MDFe.Classes/Informacoes/Evento/MDFeInfEvento.cs
@@ -14,7 +14,7 @@ namespace MDFe.Classes.Informacoes.Evento
     public class MDFeInfEvento
     {
         [XmlIgnore]
-        private readonly VersaoServico _versaoServico = MDFeConfiguracao.VersaoWebService.VersaoLayout;
+        private readonly VersaoServico _versaoServico = MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout;
 
         [XmlAttribute(AttributeName = "Id")]
         public string Id { get; set; }

--- a/MDFe.Classes/Informacoes/MDFeIde.cs
+++ b/MDFe.Classes/Informacoes/MDFeIde.cs
@@ -108,7 +108,7 @@ namespace MDFe.Classes.Informacoes
         {
             get
             {
-                switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+                switch (MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout)
                 {
                     case VersaoServico.Versao100:
                         return DhEmi.ParaDataHoraStringSemUtc();

--- a/MDFe.Servicos/ConsultaNaoEncerradosMDFe/ServicoMDFeConsultaNaoEncerrados.cs
+++ b/MDFe.Servicos/ConsultaNaoEncerradosMDFe/ServicoMDFeConsultaNaoEncerrados.cs
@@ -1,22 +1,24 @@
 using MDFe.Classes.Extencoes;
 using MDFe.Classes.Retorno.MDFeConsultaNaoEncerrado;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 
 namespace MDFe.Servicos.ConsultaNaoEncerradosMDFe
 {
     public class ServicoMDFeConsultaNaoEncerrados
     {
-        public MDFeRetConsMDFeNao MDFeConsultaNaoEncerrados(string cnpjCpf)
+        public MDFeRetConsMDFeNao MDFeConsultaNaoEncerrados(string cnpjCpf, MDFeConfiguracao cfgMdfe = null)
         {
-            var consMDFeNaoEnc = ClassesFactory.CriarConsMDFeNaoEnc(cnpjCpf);
-            consMDFeNaoEnc.ValidarSchema();
-            consMDFeNaoEnc.SalvarXmlEmDisco();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var consMDFeNaoEnc = ClassesFactory.CriarConsMDFeNaoEnc(cnpjCpf, config);
+            consMDFeNaoEnc.ValidarSchema(config);
+            consMDFeNaoEnc.SalvarXmlEmDisco(config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeConsNaoEnc();
+            var webService = WsdlFactory.CriaWsdlMDFeConsNaoEnc(config);
             var retornoXml = webService.mdfeConsNaoEnc(consMDFeNaoEnc.CriaRequestWs());
 
             var retorno = MDFeRetConsMDFeNao.LoadXmlString(retornoXml.OuterXml, consMDFeNaoEnc);
-            retorno.SalvarXmlEmDisco(cnpjCpf);
+            retorno.SalvarXmlEmDisco(cnpjCpf, config);
 
             return retorno;
         }

--- a/MDFe.Servicos/ConsultaProtocoloMDFe/ServicoMDFeConsultaProtocolo.cs
+++ b/MDFe.Servicos/ConsultaProtocoloMDFe/ServicoMDFeConsultaProtocolo.cs
@@ -1,22 +1,24 @@
 using MDFe.Classes.Extencoes;
 using MDFe.Classes.Retorno.MDFeConsultaProtocolo;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 
 namespace MDFe.Servicos.ConsultaProtocoloMDFe
 {
     public class ServicoMDFeConsultaProtocolo
     {
-        public MDFeRetConsSitMDFe MDFeConsultaProtocolo(string chave)
+        public MDFeRetConsSitMDFe MDFeConsultaProtocolo(string chave, MDFeConfiguracao cfgMdfe = null)
         {
-            var consSitMdfe = ClassesFactory.CriarConsSitMDFe(chave);
-            consSitMdfe.ValidarSchema();
-            consSitMdfe.SalvarXmlEmDisco();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var consSitMdfe = ClassesFactory.CriarConsSitMDFe(chave, config);
+            consSitMdfe.ValidarSchema(config);
+            consSitMdfe.SalvarXmlEmDisco(config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeConsulta();
+            var webService = WsdlFactory.CriaWsdlMDFeConsulta(config);
             var retornoXml = webService.mdfeConsultaMDF(consSitMdfe.CriaRequestWs());
 
             var retorno = MDFeRetConsSitMDFe.LoadXml(retornoXml.OuterXml, consSitMdfe);
-            retorno.SalvarXmlEmDisco(chave);
+            retorno.SalvarXmlEmDisco(chave, config);
 
             return retorno;
         }

--- a/MDFe.Servicos/EventosMDFe/Contratos/IServicoController.cs
+++ b/MDFe.Servicos/EventosMDFe/Contratos/IServicoController.cs
@@ -1,12 +1,13 @@
 using MDFe.Classes.Informacoes.Evento;
 using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
+using MDFe.Utils.Configuracoes;
 using MDFeEletronico = MDFe.Classes.Informacoes.MDFe;
 
 namespace MDFe.Servicos.EventosMDFe.Contratos
 {
     public interface IServicoController
     {
-        MDFeRetEventoMDFe Executar(MDFeEletronico mdfe, byte sequenciaEvento, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento);
+        MDFeRetEventoMDFe Executar(MDFeEletronico mdfe, byte sequenciaEvento, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento, MDFeConfiguracao cfgMdfe = null);
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoCancelar.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoCancelar.cs
@@ -1,17 +1,19 @@
 using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 using MDFeEletronico = MDFe.Classes.Informacoes.MDFe;
 
 namespace MDFe.Servicos.EventosMDFe
 {
     public class EventoCancelar
     {
-        public MDFeRetEventoMDFe MDFeEventoCancelar(MDFeEletronico mdfe, byte sequenciaEvento, string protocolo, string justificativa)
+        public MDFeRetEventoMDFe MDFeEventoCancelar(MDFeEletronico mdfe, byte sequenciaEvento, string protocolo, string justificativa, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var cancelamento = ClassesFactory.CriaEvCancMDFe(protocolo, justificativa);
 
-            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, cancelamento, MDFeTipoEvento.Cancelamento);
+            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, cancelamento, MDFeTipoEvento.Cancelamento, config);
 
             return retorno;
         }

--- a/MDFe.Servicos/EventosMDFe/EventoEncerramento.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoEncerramento.cs
@@ -2,26 +2,29 @@ using DFe.Classes.Entidades;
 using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 using MDFeEletronico = MDFe.Classes.Informacoes.MDFe;
 
 namespace MDFe.Servicos.EventosMDFe
 {
     public class EventoEncerramento
     {
-        public MDFeRetEventoMDFe MDFeEventoEncerramento(MDFeEletronico mdfe, byte sequenciaEvento, string protocolo)
+        public MDFeRetEventoMDFe MDFeEventoEncerramento(MDFeEletronico mdfe, byte sequenciaEvento, string protocolo, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var encerramento = ClassesFactory.CriaEvEncMDFe(mdfe, protocolo);
 
-            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, encerramento, MDFeTipoEvento.Encerramento);
+            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, encerramento, MDFeTipoEvento.Encerramento, config);
 
             return retorno;
         }
 
-        public MDFeRetEventoMDFe MDFeEventoEncerramento(MDFeEletronico mdfe, Estado estadoEncerramento, long codigoMunicipioEncerramento, byte sequenciaEvento, string protocolo)
+        public MDFeRetEventoMDFe MDFeEventoEncerramento(MDFeEletronico mdfe, Estado estadoEncerramento, long codigoMunicipioEncerramento, byte sequenciaEvento, string protocolo, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var encerramento = ClassesFactory.CriaEvEncMDFe(estadoEncerramento, codigoMunicipioEncerramento, protocolo);
 
-            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, encerramento, MDFeTipoEvento.Encerramento);
+            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, encerramento, MDFeTipoEvento.Encerramento, config);
 
             return retorno;
         }

--- a/MDFe.Servicos/EventosMDFe/EventoInclusaoCondutor.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoInclusaoCondutor.cs
@@ -1,17 +1,19 @@
 using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 using MDFeEletronico = MDFe.Classes.Informacoes.MDFe;
 
 namespace MDFe.Servicos.EventosMDFe
 {
     public class EventoInclusaoCondutor
     {
-        public MDFeRetEventoMDFe MDFeEventoIncluirCondutor(MDFeEletronico mdfe, byte sequenciaEvento, string nome, string cpf)
+        public MDFeRetEventoMDFe MDFeEventoIncluirCondutor(MDFeEletronico mdfe, byte sequenciaEvento, string nome, string cpf, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var incluirCodutor = ClassesFactory.CriaEvIncCondutorMDFe(nome, cpf);
 
-            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, incluirCodutor, MDFeTipoEvento.InclusaoDeCondutor);
+            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, incluirCodutor, MDFeTipoEvento.InclusaoDeCondutor, config);
 
             return retorno;
         }

--- a/MDFe.Servicos/EventosMDFe/EventoInclusaoDFe.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoInclusaoDFe.cs
@@ -2,6 +2,7 @@ using MDFe.Classes.Informacoes.Evento.CorpoEvento;
 using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 using System.Collections.Generic;
 using MDFeEletronico = MDFe.Classes.Informacoes.MDFe;
 
@@ -10,11 +11,12 @@ namespace MDFe.Servicos.EventosMDFe
     public class EventoInclusaoDFe
     {
         public MDFeRetEventoMDFe MDFeEventoIncluirDFe(MDFeEletronico mdfe, byte sequenciaEvento, string protocolo,
-            string codigoMunicipioCarregamento, string nomeMunicipioCarregamento, List<MDFeInfDocInc> informacoesDocumentos)
+            string codigoMunicipioCarregamento, string nomeMunicipioCarregamento, List<MDFeInfDocInc> informacoesDocumentos, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var inclusao = ClassesFactory.CriaEvIncDFeMDFe(protocolo, codigoMunicipioCarregamento, nomeMunicipioCarregamento, informacoesDocumentos);
 
-            return new ServicoController().Executar(mdfe, sequenciaEvento, inclusao, MDFeTipoEvento.InclusaoDFe);
+            return new ServicoController().Executar(mdfe, sequenciaEvento, inclusao, MDFeTipoEvento.InclusaoDFe, config);
         }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoPagamentoOperacao.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoPagamentoOperacao.cs
@@ -4,21 +4,23 @@ using MDFe.Classes.Informacoes.Evento.CorpoEvento;
 using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 
 namespace MDFe.Servicos.EventosMDFe
 {
     public class EventoPagamentoOperacao
     {
         public MDFeRetEventoMDFe MDFeEventoPagamentoOperacao(Classes.Informacoes.MDFe mdfe, byte sequencia,
-            string protocolo, infViagens infViagens, List<infPag> infPagamentos)
+            string protocolo, infViagens infViagens, List<infPag> infPagamentos, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoPagamento = ClassesFactory.CriaEvPagtoOperMDFe(
                 protocolo
                 , infViagens
                 , infPagamentos
             );
 
-            return new ServicoController().Executar(mdfe, sequencia, eventoPagamento, MDFeTipoEvento.PagamentoOperacaoMDFe);
+            return new ServicoController().Executar(mdfe, sequencia, eventoPagamento, MDFeTipoEvento.PagamentoOperacaoMDFe, config);
         }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/FactoryEvento.cs
+++ b/MDFe.Servicos/EventosMDFe/FactoryEvento.cs
@@ -9,20 +9,21 @@ namespace MDFe.Servicos.EventosMDFe
 {
     public static class FactoryEvento
     {
-        public static MDFeEventoMDFe CriaEvento(MDFeEletronico MDFe, MDFeTipoEvento tipoEvento, byte sequenciaEvento, MDFeEventoContainer evento)
+        public static MDFeEventoMDFe CriaEvento(MDFeEletronico MDFe, MDFeTipoEvento tipoEvento, byte sequenciaEvento, MDFeEventoContainer evento, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoMDFe = new MDFeEventoMDFe
             {
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
+                Versao = config.VersaoWebService.VersaoLayout,
                 InfEvento = new MDFeInfEvento
                 {
                     Id = "ID" + (long)tipoEvento + MDFe.Chave() + sequenciaEvento.ToString("D2"),
-                    TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
+                    TpAmb = config.VersaoWebService.TipoAmbiente,
                     COrgao = MDFe.UFEmitente(),
                     ChMDFe = MDFe.Chave(),
                     DetEvento = new MDFeDetEvento
                     {
-                        VersaoServico = MDFeConfiguracao.VersaoWebService.VersaoLayout,
+                        VersaoServico = config.VersaoWebService.VersaoLayout,
                         EventoContainer = evento
                     },
                     DhEvento = DateTime.Now,
@@ -39,7 +40,7 @@ namespace MDFe.Servicos.EventosMDFe
                 eventoMDFe.InfEvento.CPF = cpfEmitente;
             }
 
-            eventoMDFe.Assinar();
+            eventoMDFe.Assinar(config);
 
             return eventoMDFe;
         }

--- a/MDFe.Servicos/EventosMDFe/ServicoController.cs
+++ b/MDFe.Servicos/EventosMDFe/ServicoController.cs
@@ -4,30 +4,33 @@ using MDFe.Classes.Informacoes.Evento.Flags;
 using MDFe.Classes.Retorno.MDFeEvento;
 using MDFe.Servicos.EventosMDFe.Contratos;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 using MDFeEletronico = MDFe.Classes.Informacoes.MDFe;
 
 namespace MDFe.Servicos.EventosMDFe
 {
     public class ServicoController : IServicoController
     {
-        public MDFeRetEventoMDFe Executar(MDFeEletronico mdfe, byte sequenciaEvento, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento)
+        public MDFeRetEventoMDFe Executar(MDFeEletronico mdfe, byte sequenciaEvento, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var evento = FactoryEvento.CriaEvento(mdfe,
                 tipoEvento,
                 sequenciaEvento,
-                eventoContainer);
+                eventoContainer,
+                config);
 
 
             string chave = mdfe.Chave();
 
-            evento.ValidarSchema();
-            evento.SalvarXmlEmDisco(chave);
+            evento.ValidarSchema(config);
+            evento.SalvarXmlEmDisco(chave, config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeRecepcaoEvento();
+            var webService = WsdlFactory.CriaWsdlMDFeRecepcaoEvento(config);
             var retornoXml = webService.mdfeRecepcaoEvento(evento.CriaXmlRequestWs());
 
             var retorno = MDFeRetEventoMDFe.LoadXml(retornoXml.OuterXml, evento);
-            retorno.SalvarXmlEmDisco(chave);
+            retorno.SalvarXmlEmDisco(chave, config);
 
             return retorno;
         }

--- a/MDFe.Servicos/EventosMDFe/ServicoMDFeEvento.cs
+++ b/MDFe.Servicos/EventosMDFe/ServicoMDFeEvento.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using DFe.Classes.Entidades;
 using MDFe.Classes.Informacoes;
 using MDFeEletronica = MDFe.Classes.Informacoes.MDFe;
+using MDFe.Utils.Configuracoes;
 
 namespace MDFe.Servicos.EventosMDFe
 {
@@ -11,51 +12,57 @@ namespace MDFe.Servicos.EventosMDFe
     {
         public MDFeRetEventoMDFe MDFeEventoIncluirCondutor(
             MDFeEletronica mdfe, byte sequenciaEvento, string nome,
-            string cpf)
+            string cpf, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoIncluirCondutor = new EventoInclusaoCondutor();
 
-            return eventoIncluirCondutor.MDFeEventoIncluirCondutor(mdfe, sequenciaEvento, nome, cpf);
+            return eventoIncluirCondutor.MDFeEventoIncluirCondutor(mdfe, sequenciaEvento, nome, cpf, config);
         }
 
         public MDFeRetEventoMDFe MDFeEventoIncluirDFe(
             MDFeEletronica mdfe, byte sequenciaEvento, string protocolo,
-            string codigoMunicipioCarregamento, string nomeMunicipioCarregamento, List<MDFeInfDocInc> informacoesDocumentos)
+            string codigoMunicipioCarregamento, string nomeMunicipioCarregamento, List<MDFeInfDocInc> informacoesDocumentos, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoIncluirDFe = new EventoInclusaoDFe();
 
-            return eventoIncluirDFe.MDFeEventoIncluirDFe(mdfe, sequenciaEvento, protocolo, codigoMunicipioCarregamento, nomeMunicipioCarregamento, informacoesDocumentos);
+            return eventoIncluirDFe.MDFeEventoIncluirDFe(mdfe, sequenciaEvento, protocolo, codigoMunicipioCarregamento, nomeMunicipioCarregamento, informacoesDocumentos, config);
         }
 
-        public MDFeRetEventoMDFe MDFeEventoEncerramentoMDFeEventoEncerramento(MDFeEletronica mdfe, byte sequenciaEvento, string protocolo)
+        public MDFeRetEventoMDFe MDFeEventoEncerramentoMDFeEventoEncerramento(MDFeEletronica mdfe, byte sequenciaEvento, string protocolo, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoEncerramento = new EventoEncerramento();
 
-            return eventoEncerramento.MDFeEventoEncerramento(mdfe, sequenciaEvento, protocolo);
+            return eventoEncerramento.MDFeEventoEncerramento(mdfe, sequenciaEvento, protocolo, config);
         }
 
-        public MDFeRetEventoMDFe MDFeEventoEncerramentoMDFeEventoEncerramento(MDFeEletronica mdfe, Estado estadoEncerramento, long codigoMunicipioEncerramento, byte sequenciaEvento, string protocolo)
+        public MDFeRetEventoMDFe MDFeEventoEncerramentoMDFeEventoEncerramento(MDFeEletronica mdfe, Estado estadoEncerramento, long codigoMunicipioEncerramento, byte sequenciaEvento, string protocolo, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoEncerramento = new EventoEncerramento();
 
-            return eventoEncerramento.MDFeEventoEncerramento(mdfe, estadoEncerramento, codigoMunicipioEncerramento, sequenciaEvento, protocolo);
+            return eventoEncerramento.MDFeEventoEncerramento(mdfe, estadoEncerramento, codigoMunicipioEncerramento, sequenciaEvento, protocolo, config);
         }
 
         public MDFeRetEventoMDFe MDFeEventoCancelar(MDFeEletronica mdfe, byte sequenciaEvento, string protocolo,
-            string justificativa)
+            string justificativa, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoCancelamento = new EventoCancelar();
 
-            return eventoCancelamento.MDFeEventoCancelar(mdfe, sequenciaEvento, protocolo, justificativa);
+            return eventoCancelamento.MDFeEventoCancelar(mdfe, sequenciaEvento, protocolo, justificativa, config);
         }
 
         public MDFeRetEventoMDFe MDFeEventoPagamentoOperacaoTransporte(MDFeEletronica mdfe, byte sequenciaEvneto,
-            string protocolo, infViagens infViagens, List<infPag> infPagamentos)
+            string protocolo, infViagens infViagens, List<infPag> infPagamentos, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var eventoPagamentoOperacao = new EventoPagamentoOperacao();
 
             return eventoPagamentoOperacao.MDFeEventoPagamentoOperacao(mdfe, sequenciaEvneto, protocolo,
-                infViagens, infPagamentos);
+                infViagens, infPagamentos, config);
         }
     }
 }

--- a/MDFe.Servicos/Factory/ClassesFactory.cs
+++ b/MDFe.Servicos/Factory/ClassesFactory.cs
@@ -16,14 +16,15 @@ namespace MDFe.Servicos.Factory
 {
     public static class ClassesFactory
     {
-        public static MDFeCosMDFeNaoEnc CriarConsMDFeNaoEnc(string cnpjCpf)
+        public static MDFeCosMDFeNaoEnc CriarConsMDFeNaoEnc(string cnpjCpf, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var documentoUnico = cnpjCpf;
 
             var consMDFeNaoEnc = new MDFeCosMDFeNaoEnc
             {
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
+                TpAmb = config.VersaoWebService.TipoAmbiente,
+                Versao = config.VersaoWebService.VersaoLayout,
                 XServ = "CONSULTAR NÃO ENCERRADOS"
             };
 
@@ -51,12 +52,13 @@ namespace MDFe.Servicos.Factory
             };
         }
 
-        public static MDFeConsSitMDFe CriarConsSitMDFe(string chave)
+        public static MDFeConsSitMDFe CriarConsSitMDFe(string chave, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var consSitMdfe = new MDFeConsSitMDFe
             {
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
+                Versao = config.VersaoWebService.VersaoLayout,
+                TpAmb = config.VersaoWebService.TipoAmbiente,
                 XServ = "CONSULTAR",
                 ChMDFe = chave
             };
@@ -121,36 +123,39 @@ namespace MDFe.Servicos.Factory
             return incluirCodutor;
         }
 
-        public static MDFeEnviMDFe CriaEnviMDFe(long lote, MDFeEletronico mdfe)
+        public static MDFeEnviMDFe CriaEnviMDFe(long lote, MDFeEletronico mdfe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var enviMdfe = new MDFeEnviMDFe
             {
                 MDFe = mdfe,
                 IdLote = lote.ToString(),
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout
+                Versao = config.VersaoWebService.VersaoLayout
             };
 
             return enviMdfe;
         }
 
-        public static MDFeConsReciMDFe CriaConsReciMDFe(string numeroRecibo)
+        public static MDFeConsReciMDFe CriaConsReciMDFe(string numeroRecibo, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var consReciMDFe = new MDFeConsReciMDFe
             {
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
+                Versao = config.VersaoWebService.VersaoLayout,
+                TpAmb = config.VersaoWebService.TipoAmbiente,
                 NRec = numeroRecibo
             };
 
             return consReciMDFe;
         }
 
-        public static MDFeConsStatServMDFe CriaConsStatServMDFe()
+        public static MDFeConsStatServMDFe CriaConsStatServMDFe(MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             return new MDFeConsStatServMDFe
             {
-                TpAmb = MDFeConfiguracao.VersaoWebService.TipoAmbiente,
-                Versao = MDFeConfiguracao.VersaoWebService.VersaoLayout,
+                TpAmb = config.VersaoWebService.TipoAmbiente,
+                Versao = config.VersaoWebService.VersaoLayout,
                 XServ = "STATUS"
             };
         }

--- a/MDFe.Servicos/Factory/WsdlFactory.cs
+++ b/MDFe.Servicos/Factory/WsdlFactory.cs
@@ -15,80 +15,88 @@ namespace MDFe.Servicos.Factory
 {
     public static class WsdlFactory
     {
-        public static MDFeConsNaoEnc CriaWsdlMDFeConsNaoEnc()
+        public static MDFeConsNaoEnc CriaWsdlMDFeConsNaoEnc(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeConsNaoEnc;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeConsNaoEnc;
+            var versao = config.VersaoWebService.VersaoLayout.GetVersaoString();
+            var configuracaoWsdl = CriaConfiguracao(url, versao, config);
 
             var ws = new MDFeConsNaoEnc(configuracaoWsdl);
             return ws;
         }
 
-        public static MDFeConsulta CriaWsdlMDFeConsulta()
+        public static MDFeConsulta CriaWsdlMDFeConsulta(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeConsulta;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeConsulta;
+            var versao = config.VersaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, config);
 
             return new MDFeConsulta(configuracaoWsdl);
         }
 
-        public static MDFeRecepcaoEvento CriaWsdlMDFeRecepcaoEvento()
+        public static MDFeRecepcaoEvento CriaWsdlMDFeRecepcaoEvento(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRecepcaoEvento;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeRecepcaoEvento;
+            var versao = config.VersaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, config);
 
             return new MDFeRecepcaoEvento(configuracaoWsdl);
         }
 
-        public static MDFeRecepcao CriaWsdlMDFeRecepcao()
+        public static MDFeRecepcao CriaWsdlMDFeRecepcao(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRecepcao;
-            var versaoServico = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeRecepcao;
+            var versaoServico = config.VersaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, versaoServico, config);
 
             return new MDFeRecepcao(configuracaoWsdl);
         }
 
-        public static MDFeRecepcaoSinc CriaWsdlMDFeRecepcaoSinc()
+        public static MDFeRecepcaoSinc CriaWsdlMDFeRecepcaoSinc(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRecepcaoSinc;
-            var versaoServico = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeRecepcaoSinc;
+            var versaoServico = config.VersaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versaoServico);
+            var configuracaoWsdl = CriaConfiguracao(url, versaoServico, config);
 
             return new MDFeRecepcaoSinc(configuracaoWsdl);
         }
 
-        public static MDFeRetRecepcao CriaWsdlMDFeRetRecepcao()
+        public static MDFeRetRecepcao CriaWsdlMDFeRetRecepcao(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeRetRecepcao;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeRetRecepcao;
+            var versao = config.VersaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, config);
 
             return new MDFeRetRecepcao(configuracaoWsdl);
         }
 
-        public static MDFeStatusServico CriaWsdlMDFeStatusServico()
+        public static MDFeStatusServico CriaWsdlMDFeStatusServico(MDFeConfiguracao cfgMdfe = null)
         {
-            var url = UrlHelper.ObterUrlServico(MDFeConfiguracao.VersaoWebService.TipoAmbiente).MDFeStatusServico;
-            var versao = MDFeConfiguracao.VersaoWebService.VersaoLayout.GetVersaoString();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var url = UrlHelper.ObterUrlServico(config.VersaoWebService.TipoAmbiente).MDFeStatusServico;
+            var versao = config.VersaoWebService.VersaoLayout.GetVersaoString();
 
-            var configuracaoWsdl = CriaConfiguracao(url, versao);
+            var configuracaoWsdl = CriaConfiguracao(url, versao, config);
 
             return new MDFeStatusServico(configuracaoWsdl);
         }
 
-        private static WsdlConfiguracao CriaConfiguracao(string url, string versao)
+        private static WsdlConfiguracao CriaConfiguracao(string url, string versao, MDFeConfiguracao cfgMdfe = null)
         {
-            var codigoEstado = MDFeConfiguracao.VersaoWebService.UfEmitente.GetCodigoIbgeEmString();
-            var certificadoDigital = MDFeConfiguracao.X509Certificate2;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var codigoEstado = config.VersaoWebService.UfEmitente.GetCodigoIbgeEmString();
+            var certificadoDigital = config.X509Certificate2;
 
             return new WsdlConfiguracao
             {
@@ -96,7 +104,7 @@ namespace MDFe.Servicos.Factory
                 Versao = versao,
                 CodigoIbgeEstado = codigoEstado,
                 Url = url,
-                TimeOut = MDFeConfiguracao.VersaoWebService.TimeOut
+                TimeOut = config.VersaoWebService.TimeOut
             };
         }
     }

--- a/MDFe.Servicos/RecepcaoMDFe/ServicoMDFeRecepcao.cs
+++ b/MDFe.Servicos/RecepcaoMDFe/ServicoMDFeRecepcao.cs
@@ -17,11 +17,12 @@ namespace MDFe.Servicos.RecepcaoMDFe
         public event EventHandler<AntesDeEnviar> AntesDeEnviar;
         public event EventHandler<string> GerouChave; 
 
-        public MDFeRetEnviMDFe MDFeRecepcao(long lote, MDFeEletronico mdfe)
+        public MDFeRetEnviMDFe MDFeRecepcao(long lote, MDFeEletronico mdfe, MDFeConfiguracao cfgMdfe = null)
         {
-            var enviMDFe = ClassesFactory.CriaEnviMDFe(lote, mdfe);
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var enviMDFe = ClassesFactory.CriaEnviMDFe(lote, mdfe, config);
 
-            switch (MDFeConfiguracao.VersaoWebService.VersaoLayout)
+            switch (config.VersaoWebService.VersaoLayout)
             {
                 case VersaoServico.Versao100:
                     mdfe.InfMDFe.InfModal.VersaoModal = MDFeVersaoModal.Versao100;
@@ -33,43 +34,44 @@ namespace MDFe.Servicos.RecepcaoMDFe
                     break;
             }
 
-            enviMDFe.MDFe.Assina(GerouChave, this);
+            enviMDFe.MDFe.Assina(GerouChave, this, config);
 
-            if (MDFeConfiguracao.IsAdicionaQrCode && MDFeConfiguracao.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
+            if (config.IsAdicionaQrCode && config.VersaoWebService.VersaoLayout == VersaoServico.Versao300)
             {
-                mdfe.infMDFeSupl = mdfe.QrCode(MDFeConfiguracao.X509Certificate2);
+                mdfe.infMDFeSupl = mdfe.QrCode(config.X509Certificate2);
             }
 
-            enviMDFe.Valida();
-            enviMDFe.SalvarXmlEmDisco();
+            enviMDFe.Valida(config);
+            enviMDFe.SalvarXmlEmDisco(config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeRecepcao();
+            var webService = WsdlFactory.CriaWsdlMDFeRecepcao(config);
 
             OnAntesDeEnviar(enviMDFe);
 
             var retornoXml = webService.mdfeRecepcaoLote(enviMDFe.CriaXmlRequestWs());
 
             var retorno = MDFeRetEnviMDFe.LoadXml(retornoXml.OuterXml, enviMDFe);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(config);
 
             return retorno;
         }
 
-        public MDFeRetMDFe MDFeRecepcaoSinc(MDFeEletronico mdfe)
+        public MDFeRetMDFe MDFeRecepcaoSinc(MDFeEletronico mdfe, MDFeConfiguracao cfgMdfe = null)
         {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             mdfe.InfMDFe.InfModal.VersaoModal = MDFeVersaoModal.Versao300;
             mdfe.InfMDFe.Ide.ProxyDhIniViagem = mdfe.InfMDFe.Ide.DhIniViagem.ParaDataHoraStringUtc();
-            mdfe.Assina(GerouChave, this);
+            mdfe.Assina(GerouChave, this, config);
 
-            if (MDFeConfiguracao.IsAdicionaQrCode)
+            if (config.IsAdicionaQrCode)
             {
-                mdfe.infMDFeSupl = mdfe.QrCode(MDFeConfiguracao.X509Certificate2);
+                mdfe.infMDFeSupl = mdfe.QrCode(config.X509Certificate2);
             }
 
-            mdfe.Valida();
-            mdfe.SalvarXmlEmDisco();
+            mdfe.Valida(config);
+            mdfe.SalvarXmlEmDisco(cfgMdfe: config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeRecepcaoSinc();
+            var webService = WsdlFactory.CriaWsdlMDFeRecepcaoSinc(config);
 
             OnAntesDeEnviar(new MDFeEnviMDFe
             {

--- a/MDFe.Servicos/RetRecepcaoMDFe/ServicoMDFeRetRecepcao.cs
+++ b/MDFe.Servicos/RetRecepcaoMDFe/ServicoMDFeRetRecepcao.cs
@@ -1,22 +1,24 @@
 using MDFe.Classes.Extencoes;
 using MDFe.Classes.Retorno.MDFeRetRecepcao;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 
 namespace MDFe.Servicos.RetRecepcaoMDFe
 {
     public class ServicoMDFeRetRecepcao
     {
-        public MDFeRetConsReciMDFe MDFeRetRecepcao(string numeroRecibo)
+        public MDFeRetConsReciMDFe MDFeRetRecepcao(string numeroRecibo, MDFeConfiguracao cfgMdfe = null)
         {
-            var consReciMdfe = ClassesFactory.CriaConsReciMDFe(numeroRecibo);
-            consReciMdfe.ValidaSchema();
-            consReciMdfe.SalvarXmlEmDisco();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var consReciMdfe = ClassesFactory.CriaConsReciMDFe(numeroRecibo, config);
+            consReciMdfe.ValidaSchema(config);
+            consReciMdfe.SalvarXmlEmDisco(config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeRetRecepcao();
+            var webService = WsdlFactory.CriaWsdlMDFeRetRecepcao(config);
             var retornoXml = webService.mdfeRetRecepcao(consReciMdfe.CriaRequestWs());
 
             var retorno = MDFeRetConsReciMDFe.LoadXml(retornoXml.OuterXml, consReciMdfe);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(config);
 
             return retorno;
         }

--- a/MDFe.Servicos/StatusServicoMDFe/ServicoMDFeStatusServico.cs
+++ b/MDFe.Servicos/StatusServicoMDFe/ServicoMDFeStatusServico.cs
@@ -1,22 +1,24 @@
 using MDFe.Classes.Extencoes;
 using MDFe.Classes.Retorno.MDFeStatusServico;
 using MDFe.Servicos.Factory;
+using MDFe.Utils.Configuracoes;
 
 namespace MDFe.Servicos.StatusServicoMDFe
 {
     public class ServicoMDFeStatusServico
     {
-        public MDFeRetConsStatServ MDFeStatusServico()
+        public MDFeRetConsStatServ MDFeStatusServico(MDFeConfiguracao cfgMdfe = null)
         {
-            var consStatServMDFe = ClassesFactory.CriaConsStatServMDFe();
-            consStatServMDFe.ValidarSchema();
-            consStatServMDFe.SalvarXmlEmDisco();
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var consStatServMDFe = ClassesFactory.CriaConsStatServMDFe(config);
+            consStatServMDFe.ValidarSchema(config);
+            consStatServMDFe.SalvarXmlEmDisco(config);
 
-            var webService = WsdlFactory.CriaWsdlMDFeStatusServico();
+            var webService = WsdlFactory.CriaWsdlMDFeStatusServico(config);
             var retornoXml = webService.mdfeStatusServicoMDF(consStatServMDFe.CriaRequestWs());
 
             var retorno = MDFeRetConsStatServ.LoadXml(retornoXml.OuterXml, consStatServMDFe);
-            retorno.SalvarXmlEmDisco();
+            retorno.SalvarXmlEmDisco(config);
 
             return retorno;
 

--- a/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
+++ b/MDFe.Utils/Configuracoes/MDFeConfiguracao.cs
@@ -10,27 +10,30 @@ namespace MDFe.Utils.Configuracoes
 {
     public class MDFeConfiguracao : IDisposable 
     {
-        private static MDFeVersaoWebService _versaoWebService;
+        private static volatile MDFeConfiguracao _instancia;
+        private static readonly object SyncRoot = new object();
+
+        private MDFeVersaoWebService _versaoWebService;
 
         public MDFeConfiguracao()
         {
             VersaoWebService = new MDFeVersaoWebService();
         }
 
-        public static ConfiguracaoCertificado ConfiguracaoCertificado { get; set; }
+        public ConfiguracaoCertificado ConfiguracaoCertificado { get; set; }
 
-        public static bool IsSalvarXml { get; set; }
-        public static string CaminhoSchemas { get; set; }
-        public static string CaminhoSalvarXml { get; set; }
-        public static bool IsAdicionaQrCode { get; set; }
+        public bool IsSalvarXml { get; set; }
+        public string CaminhoSchemas { get; set; }
+        public string CaminhoSalvarXml { get; set; }
+        public bool IsAdicionaQrCode { get; set; }
 
-        public static MDFeVersaoWebService VersaoWebService
+        public MDFeVersaoWebService VersaoWebService
         {
             get { return GetMdfeVersaoWebService(); }
             set { _versaoWebService = value; }
         }
 
-        private static MDFeVersaoWebService GetMdfeVersaoWebService()
+        private MDFeVersaoWebService GetMdfeVersaoWebService()
         {
             if(_versaoWebService == null)
                 _versaoWebService = new MDFeVersaoWebService();
@@ -38,8 +41,8 @@ namespace MDFe.Utils.Configuracoes
             return _versaoWebService;
         }
 
-        private static X509Certificate2 _certificado = null;
-        public static X509Certificate2 X509Certificate2
+        private X509Certificate2 _certificado = null;
+        public X509Certificate2 X509Certificate2
         {
             get
             {
@@ -51,12 +54,27 @@ namespace MDFe.Utils.Configuracoes
             }
         }
 
-        public static bool NaoSalvarXml()
+        public static MDFeConfiguracao Instancia
+        {
+            get
+            {
+                if (_instancia != null) return _instancia;
+                lock (SyncRoot)
+                {
+                    if (_instancia != null) return _instancia;
+                    _instancia = new MDFeConfiguracao();
+                }
+
+                return _instancia;
+            }
+        }
+
+        public bool NaoSalvarXml()
         {
             return !IsSalvarXml;
         }
 
-        private static X509Certificate2 ObterCertificado()
+        private X509Certificate2 ObterCertificado()
         {
             return CertificadoDigital.ObterCertificado(ConfiguracaoCertificado);
         }

--- a/MDFe.Utils/Validacao/Validador.cs
+++ b/MDFe.Utils/Validacao/Validador.cs
@@ -8,9 +8,10 @@ namespace MDFe.Utils.Validacao
 {
     public class Validador
     {
-        public static void Valida(string xml, string schema)
+        public static void Valida(string xml, string schema, MDFeConfiguracao cfgMdfe = null)
         {
-            var pathSchema = MDFeConfiguracao.CaminhoSchemas;
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var pathSchema = config.CaminhoSchemas;
 
             if (!Directory.Exists(pathSchema))
                 throw new Exception("Diretório de Schemas não encontrado: \n" + pathSchema);


### PR DESCRIPTION
Ver #46 

Transformada classe MDFeConfiguracao de static para singleton para permitir configurações em ambientes multi-empresa.

Para simplificar o PR foquei só na alteração do static, seguindo o padrão das classes NF-e.

Testado em nossa aplicação que está em desenvolvimento (ainda não consigo testar múltiplas empresas):
- Emissão e autorização
- Cancelamento
- Encerramento