### PR TITLE
Erro de validação de instância: '00' não é um valor válido para BandeiraCartao.

### DIFF
--- a/NFe.Classes/Informacoes/Pagamento/pagTipos.cs
+++ b/NFe.Classes/Informacoes/Pagamento/pagTipos.cs
@@ -28,6 +28,13 @@ namespace NFe.Classes.Informacoes.Pagamento
     /// </summary>
     public enum FormaPagamento
     {
+		/// <summary>
+        /// >00 - Nenhum (nota emitida e aprovada com este codigo causando problema na distribuicao)
+        /// </summary>
+        [Description("Nenhum")]
+        [XmlEnum("00")]
+        bcNenhum = 00,
+	  
         /// <summary>
         /// 01 - Dinheiro
         /// </summary>


### PR DESCRIPTION
Ao executar a consulta de NFe no serviço de distribuição, o fornecedor emitiu a NFe com tband 00 e SEFAZ aceitou, porém no serivço ocorre a falha {"Erro de validação de instância: '00' não é um valor válido para BandeiraCartao."}