### PR TITLE
fix(nfe): erro ao imprimir InfAdicionais com colchetes

### DIFF
--- a/NFe.Danfe.Base/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Base/NFe/NFeRetrato.frx
@@ -1444,7 +1444,7 @@ namespace FastReport
     </DataBand>
     <PageFooterBand Name="DadosAdicionais" Top="973.71" Width="744.66" Height="60.15" CanGrow="true" PrintOn="FirstPage">
       <TextObject Name="Text155" Top="13.46" Width="470.06" Height="45.36" Border.Lines="All" Border.Width="0.5" CanGrow="true" GrowToBottom="true" CanBreak="false" Text="INFORMAÇÕES COMPLEMENTARES" Padding="2, 2, 2, 0" Font="Times New Roman, 5pt, style=Bold"/>
-      <TextObject Name="TextInfAdicionais" Left="1.45" Top="26.91" Width="468.5" Height="29.8" CanGrow="true" GrowToBottom="true" CanBreak="false" Font="Times New Roman, 8pt"/>
+      <TextObject Name="TextInfAdicionais" Left="1.45" Top="26.91" Width="468.5" Height="29.8" CanGrow="true" GrowToBottom="true" CanBreak="false" Font="Times New Roman, 8pt" AllowExpressions="False" />
       <TextObject Name="Text156" Left="470.5" Top="13.46" Width="274.06" Height="45.36" Border.Lines="All" Border.Width="0.5" CanGrow="true" GrowToBottom="true" CanBreak="false" Text="RESERVADO AO FISCO" Padding="2, 2, 2, 0" Font="Times New Roman, 5pt, style=Bold"/>
       <TextObject Name="Text37" Left="472.5" Top="26.91" Width="270.05" Height="29.8" CanGrow="true" GrowToBottom="true" CanBreak="false" Text="[NFe.protNFe.infProt.cMsg] [NFe.protNFe.infProt.xMsg]" Font="Times New Roman, 8pt"/>
       <TextObject Name="Text157" Left="1.89" Top="1.89" Width="124.65" Height="9.35" Text="DADOS ADICIONAIS" Padding="0, 0, 0, 0" VertAlign="Center" Font="Times New Roman, 8pt, style=Bold"/>


### PR DESCRIPTION
## Xml com colchetes no InfAdicionais gera erro na impressão:
```
<infAdFisco>Total desconto concedido: 9,90 [; 15] Imposto.</infAdFisco>
```

Como no fast report colchetes é interpretado como expressão, ele gera um erro ao carregar o relatório:

```
TextInfAdicionais: Error in expression: [; 15]
```

Resolvido mudando o [Allow Expression] do TextInfAdicionais para False.