### PR TITLE
Migrado para .NET 9 em uma tentativa de resolver Erro de SSL

### DIFF
--- a/CTe.AppTeste.NetCore/CTe.AppTeste.NetCore.csproj
+++ b/CTe.AppTeste.NetCore/CTe.AppTeste.NetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CTe.Classes/CTe.Classes.csproj
+++ b/CTe.Classes/CTe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/CTe.Dacte.Base/CTe.Dacte.Base.csproj
+++ b/CTe.Dacte.Base/CTe.Dacte.Base.csproj
@@ -1,28 +1,39 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
-	  
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48'">
 		<PackageReference Include="System.Drawing.Common">
-			<Version>6.0.0</Version>
+			<Version>6.0.*</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+		<PackageReference Include="System.Drawing.Common">
+			<Version>8.0.*</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+		<PackageReference Include="System.Drawing.Common">
+			<Version>9.0.*</Version>
 		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Remove="CTe\CTeEvento.frx" />
-	  <None Remove="CTe\CTeRetrato.frx" />
+		<None Remove="CTe\CTeEvento.frx" />
+		<None Remove="CTe\CTeRetrato.frx" />
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Content Include="CTe\CTeEvento.frx">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </Content>
-	  <Content Include="CTe\CTeRetrato.frx">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </Content>
+		<Content Include="CTe\CTeEvento.frx">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+		<Content Include="CTe\CTeRetrato.frx">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
 	</ItemGroup>
 
 </Project>

--- a/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
+++ b/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		<DefineConstants>openfastreport</DefineConstants>
 		
 	</PropertyGroup>

--- a/CTe.Servicos/CTe.Servicos.csproj
+++ b/CTe.Servicos/CTe.Servicos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/CTe.Utils/CTe.Utils.csproj
+++ b/CTe.Utils/CTe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/CTe.Wsdl/CTe.Wsdl.csproj
+++ b/CTe.Wsdl/CTe.Wsdl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/DFe.Classes/DFe.Classes.csproj
+++ b/DFe.Classes/DFe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	
   </PropertyGroup>
 	

--- a/DFe.Testes/DFe.Testes.csproj
+++ b/DFe.Testes/DFe.Testes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		
 	</PropertyGroup>

--- a/DFe.Utils/DFe.Utils.csproj
+++ b/DFe.Utils/DFe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		
 	</PropertyGroup>
 

--- a/DFe.Wsdl/Common/ConfiguracaoServicoWSDL.cs
+++ b/DFe.Wsdl/Common/ConfiguracaoServicoWSDL.cs
@@ -20,7 +20,15 @@ namespace DFe.Wsdl.Common
         static ConfiguracaoServicoWSDL()
         {
             ValidarCertificadoDoServidorNetCore = true;
+
+            //a partir de .net 9 utilizar o HttpClient
+            //pois o WebRequest, HttpWebRequest, ServicePoint, and WebClient foi DESCONTINUADO
+            //Ver https://github.com/Hercules-NET/ZeusFiscal/issues/59
+#if NET9_0_OR_GREATER
+            SetRequestSefazFactory(() => new RequestSefazHttpClientHandler());
+#else
             SetRequestSefazFactory(() => new RequestSefazDefault());
+#endif
         }
     }
 }

--- a/DFe.Wsdl/Common/RequestSefazHttpClientHandler.cs
+++ b/DFe.Wsdl/Common/RequestSefazHttpClientHandler.cs
@@ -47,7 +47,6 @@ namespace DFe.Wsdl.Common
             string url, int timeOut,
             TipoEvento? tipoEvento = null, string actionUrn = "")
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             if (!tipoEvento.HasValue && string.IsNullOrWhiteSpace(actionUrn))
             {
                 throw new ArgumentNullException(
@@ -63,6 +62,7 @@ namespace DFe.Wsdl.Common
 
             using (HttpClientHandler handler = new HttpClientHandler())
             {
+                handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
                 handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
                 handler.ClientCertificates.Add(certificadoDigital);
 
@@ -87,7 +87,6 @@ namespace DFe.Wsdl.Common
         public string SendRequest(XmlDocument xmlEnvelop, X509Certificate2 certificadoDigital, string url, int timeOut,
             TipoEvento? tipoEvento = null, string actionUrn = "")
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             if (!tipoEvento.HasValue && string.IsNullOrWhiteSpace(actionUrn))
             {
                 throw new ArgumentNullException(
@@ -103,6 +102,7 @@ namespace DFe.Wsdl.Common
 
             using (HttpClientHandler handler = new HttpClientHandler())
             {
+                handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
                 handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
                 handler.ClientCertificates.Add(certificadoDigital);
 

--- a/DFe.Wsdl/Common/RequestSefazHttpClientHandler.cs
+++ b/DFe.Wsdl/Common/RequestSefazHttpClientHandler.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -62,8 +63,14 @@ namespace DFe.Wsdl.Common
 
             using (HttpClientHandler handler = new HttpClientHandler())
             {
-                handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
-                handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;//para net8 ou outras versoes
+                handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;//NET 9+
+
+                ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => { return true; };//para net8 ou outras versoes
+                handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => { return true; };//NET 9+
+
+                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                handler.CheckCertificateRevocationList = false;
                 handler.ClientCertificates.Add(certificadoDigital);
 
                 using (HttpClient client = new HttpClient(handler))
@@ -100,10 +107,17 @@ namespace DFe.Wsdl.Common
 
             string xmlSoap = xmlEnvelop.InnerXml;
 
+
             using (HttpClientHandler handler = new HttpClientHandler())
             {
-                handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;
-                handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => true;
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;//para net8 ou outras versoes
+                handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls12;//NET 9+
+
+                ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, sslPolicyErrors) => { return true; };//para net8 ou outras versoes
+                handler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) => { return true; };//NET 9+
+
+                handler.ClientCertificateOptions = ClientCertificateOption.Manual;
+                handler.CheckCertificateRevocationList = false;
                 handler.ClientCertificates.Add(certificadoDigital);
 
                 using (HttpClient client = new HttpClient(handler))

--- a/DFe.Wsdl/DFe.Wsdl.csproj
+++ b/DFe.Wsdl/DFe.Wsdl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Classes/MDFe.Classes.csproj
+++ b/MDFe.Classes/MDFe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Damdfe.Base/MDFe.Damdfe.Base.csproj
+++ b/MDFe.Damdfe.Base/MDFe.Damdfe.Base.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
 		<PackageReference Include="System.Drawing.Common">
 			<Version>6.0.0</Version>
 		</PackageReference>

--- a/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
+++ b/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		<DefineConstants>openfastreport</DefineConstants>
 		
 	</PropertyGroup>

--- a/MDFe.Servicos/MDFe.Servicos.csproj
+++ b/MDFe.Servicos/MDFe.Servicos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Utils/MDFe.Utils.csproj
+++ b/MDFe.Utils/MDFe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Wsdl/MDFe.Wsdl.csproj
+++ b/MDFe.Wsdl/MDFe.Wsdl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/NFe.AppTeste.NetCore/NFe.AppTeste.NetCore.csproj
+++ b/NFe.AppTeste.NetCore/NFe.AppTeste.NetCore.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>

--- a/NFe.AppTeste.NetCore/Program.cs
+++ b/NFe.AppTeste.NetCore/Program.cs
@@ -175,7 +175,7 @@ namespace NFe.AppTeste.NetCore
                 #region Status do serviço
                 using (ServicosNFe servicoNFe = new ServicosNFe(_configuracoes.CfgServico))
                 {
-                    var retornoStatus = servicoNFe.NfeStatusServico();
+                    var retornoStatus = servicoNFe.NfeStatusServico(exceptionCompleta: true);
                     OnSucessoSync(retornoStatus);
                 }
                 #endregion

--- a/NFe.Classes/NFe.Classes.csproj
+++ b/NFe.Classes/NFe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/NFe.Danfe.App.Teste.Html/NFe.Danfe.App.Teste.Html.csproj
+++ b/NFe.Danfe.App.Teste.Html/NFe.Danfe.App.Teste.Html.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
   </PropertyGroup>

--- a/NFe.Danfe.AppTeste.OpenFast/NFe.Danfe.AppTeste.OpenFast.csproj
+++ b/NFe.Danfe.AppTeste.OpenFast/NFe.Danfe.AppTeste.OpenFast.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		
 	</PropertyGroup>

--- a/NFe.Danfe.Base/NFe.Danfe.Base.csproj
+++ b/NFe.Danfe.Base/NFe.Danfe.Base.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net6.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="System.Drawing.Common">
       <Version>6.0.0</Version>
     </PackageReference>

--- a/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
+++ b/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<DefineConstants>fastskia</DefineConstants>
 	</PropertyGroup>
 

--- a/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
+++ b/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<DefineConstants>fastskia</DefineConstants>
 	</PropertyGroup>
 

--- a/NFe.Danfe.Nativo/NFe.Danfe.Nativo.csproj
+++ b/NFe.Danfe.Nativo/NFe.Danfe.Nativo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net6.0-windows</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
+++ b/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		<DefineConstants>openfastreport</DefineConstants>
 		
 	</PropertyGroup>

--- a/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
+++ b/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>

--- a/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
+++ b/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
@@ -1,10 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
+	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	  <ImplicitUsings>enable</ImplicitUsings>
+	  <Nullable>enable</Nullable>
+	  <LangVersion>latest</LangVersion>
+
   </PropertyGroup>
 
   <ItemGroup>

--- a/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
+++ b/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
+++ b/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	  <ImplicitUsings>enable</ImplicitUsings>
+	  <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NFe.Servicos/NFe.Servicos.csproj
+++ b/NFe.Servicos/NFe.Servicos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		
 	</PropertyGroup>
 
@@ -11,7 +11,7 @@
 		<ProjectReference Include="..\NFe.Wsdl\NFe.Wsdl.csproj" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net6.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
 		<ProjectReference Include="..\NFe.Wsdl.Standard\NFe.Wsdl.Standard.csproj" />
 	</ItemGroup>
 

--- a/NFe.Utils.Testes/NFe.Utils.Testes.csproj
+++ b/NFe.Utils.Testes/NFe.Utils.Testes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 		
 	</PropertyGroup>

--- a/NFe.Utils/NFe.Utils.csproj
+++ b/NFe.Utils/NFe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	  
   </PropertyGroup>
 	

--- a/NFe.Wsdl.Standard/NFe.Wsdl.Standard.csproj
+++ b/NFe.Wsdl.Standard/NFe.Wsdl.Standard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		
 	</PropertyGroup>
 

--- a/NuGet/Hercules.NET.CTe/Hercules.NET.CTe.csproj
+++ b/NuGet/Hercules.NET.CTe/Hercules.NET.CTe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.CTe/Hercules.NET.CTe.nuspec
+++ b/NuGet/Hercules.NET.CTe/Hercules.NET.CTe.nuspec
@@ -24,13 +24,21 @@
 		<file src="..\..\CTe.Utils\bin\Release\netstandard2.0\CTe.Utils.dll" target="lib/netstandard2.0/CTe.Utils.dll" />
 		<file src="..\..\CTe.Wsdl\bin\Release\netstandard2.0\CTe.Wsdl.dll" target="lib/netstandard2.0/CTe.Wsdl.dll" />
 
-		<file src="..\..\DFe.Classes\bin\Release\net6.0\DFe.Classes.dll" target="lib/net6.0/DFe.Classes.dll" />
-		<file src="..\..\DFe.Utils\bin\Release\net6.0\DFe.Utils.dll" target="lib/net6.0/DFe.Utils.dll" />
-		<file src="..\..\DFe.Wsdl\bin\Release\net6.0\DFe.Wsdl.dll" target="lib/net6.0/DFe.Wsdl.dll" />
-		<file src="..\..\CTe.Classes\bin\Release\net6.0\CTe.Classes.dll" target="lib/net6.0/CTe.Classes.dll" />
-		<file src="..\..\CTe.Servicos\bin\Release\net6.0\CTe.Servicos.dll" target="lib/net6.0/CTe.Servicos.dll" />
-		<file src="..\..\CTe.Utils\bin\Release\net6.0\CTe.Utils.dll" target="lib/net6.0/CTe.Utils.dll" />
-		<file src="..\..\CTe.Wsdl\bin\Release\net6.0\CTe.Wsdl.dll" target="lib/net6.0/CTe.Wsdl.dll" />
+		<file src="..\..\DFe.Classes\bin\Release\net8.0\DFe.Classes.dll" target="lib/net8.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net8.0\DFe.Utils.dll" target="lib/net8.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net8.0\DFe.Wsdl.dll" target="lib/net8.0/DFe.Wsdl.dll" />
+		<file src="..\..\CTe.Classes\bin\Release\net8.0\CTe.Classes.dll" target="lib/net8.0/CTe.Classes.dll" />
+		<file src="..\..\CTe.Servicos\bin\Release\net8.0\CTe.Servicos.dll" target="lib/net8.0/CTe.Servicos.dll" />
+		<file src="..\..\CTe.Utils\bin\Release\net8.0\CTe.Utils.dll" target="lib/net8.0/CTe.Utils.dll" />
+		<file src="..\..\CTe.Wsdl\bin\Release\net8.0\CTe.Wsdl.dll" target="lib/net8.0/CTe.Wsdl.dll" />
+
+		<file src="..\..\DFe.Classes\bin\Release\net9.0\DFe.Classes.dll" target="lib/net9.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net9.0\DFe.Utils.dll" target="lib/net9.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net9.0\DFe.Wsdl.dll" target="lib/net9.0/DFe.Wsdl.dll" />
+		<file src="..\..\CTe.Classes\bin\Release\net9.0\CTe.Classes.dll" target="lib/net9.0/CTe.Classes.dll" />
+		<file src="..\..\CTe.Servicos\bin\Release\net9.0\CTe.Servicos.dll" target="lib/net9.0/CTe.Servicos.dll" />
+		<file src="..\..\CTe.Utils\bin\Release\net9.0\CTe.Utils.dll" target="lib/net9.0/CTe.Utils.dll" />
+		<file src="..\..\CTe.Wsdl\bin\Release\net9.0\CTe.Wsdl.dll" target="lib/net9.0/CTe.Wsdl.dll" />
 		
 		<file src="..\..\DFe.Classes\bin\Release\net462\DFe.Classes.dll" target="lib/net462/DFe.Classes.dll" />
 		<file src="..\..\DFe.Utils\bin\Release\net462\DFe.Utils.dll" target="lib/net462/DFe.Utils.dll" />

--- a/NuGet/Hercules.NET.Impressao.NFCe.QuestPdf/Hercules.NET.Impressao.NFCe.QuestPdf.csproj
+++ b/NuGet/Hercules.NET.Impressao.NFCe.QuestPdf/Hercules.NET.Impressao.NFCe.QuestPdf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net6.0</TargetFrameworks>
+	<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.Impressao.NFCe.QuestPdf/Hercules.NET.Impressao.NFCe.QuestPdf.nuspec
+++ b/NuGet/Hercules.NET.Impressao.NFCe.QuestPdf/Hercules.NET.Impressao.NFCe.QuestPdf.nuspec
@@ -17,7 +17,16 @@
   </metadata>
   <dependencies>
 
-		  <group targetFramework="net6.0">
+		  <group targetFramework="net8.0">
+			<dependency id="BarcodeLib" version="3.1.4" />
+			<dependency id="HarfBuzzSharp.NativeAssets.Linux" version="7.3.0.2" />
+			<dependency id="Hercules.NET.NFe.NFCe" version="2024.9.19.1844" />
+			<dependency id="QuestPDF" version="2024.7.3" />
+			<dependency id="SkiaSharp.NativeAssets.Linux.NoDependencies" version="2.88.8" />
+			<dependency id="SkiaSharp.QrCode" version="0.7.0" />
+		  </group>
+
+		  <group targetFramework="net9.0">
 			<dependency id="BarcodeLib" version="3.1.4" />
 			<dependency id="HarfBuzzSharp.NativeAssets.Linux" version="7.3.0.2" />
 			<dependency id="Hercules.NET.NFe.NFCe" version="2024.9.19.1844" />
@@ -29,6 +38,7 @@
 		</dependencies>
 
   <files>
-    <file src="..\..\NFe.Danfe.QuestPdf\bin\Release\net6.0\NFe.Danfe.QuestPdf.dll" target="src\NFe.Danfe.QuestPdf.dll" />
+    <file src="..\..\NFe.Danfe.QuestPdf\bin\Release\net8.0\NFe.Danfe.QuestPdf.dll" target="src\NFe.Danfe.QuestPdf.dll" />
+    <file src="..\..\NFe.Danfe.QuestPdf\bin\Release\net9.0\NFe.Danfe.QuestPdf.dll" target="src\NFe.Danfe.QuestPdf.dll" />
   </files>
 </package>

--- a/NuGet/Hercules.NET.MDFe/Hercules.NET.MDFe.csproj
+++ b/NuGet/Hercules.NET.MDFe/Hercules.NET.MDFe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.MDFe/Hercules.NET.MDFe.nuspec
+++ b/NuGet/Hercules.NET.MDFe/Hercules.NET.MDFe.nuspec
@@ -24,13 +24,21 @@
 		<file src="..\..\MDFe.Utils\bin\Release\netstandard2.0\MDFe.Utils.dll" target="lib/netstandard2.0/MDFe.Utils.dll" />
 		<file src="..\..\MDFe.Wsdl\bin\Release\netstandard2.0\MDFe.Wsdl.dll" target="lib/netstandard2.0/MDFe.Wsdl.dll" />
 		
-		<file src="..\..\DFe.Classes\bin\Release\net6.0\DFe.Classes.dll" target="lib/net6.0/DFe.Classes.dll" />
-		<file src="..\..\DFe.Utils\bin\Release\net6.0\DFe.Utils.dll" target="lib/net6.0/DFe.Utils.dll" />
-		<file src="..\..\DFe.Wsdl\bin\Release\net6.0\DFe.Wsdl.dll" target="lib/net6.0/DFe.Wsdl.dll" />
-		<file src="..\..\MDFe.Classes\bin\Release\net6.0\MDFe.Classes.dll" target="lib/net6.0/MDFe.Classes.dll" />
-		<file src="..\..\MDFe.Servicos\bin\Release\net6.0\MDFe.Servicos.dll" target="lib/net6.0/MDFe.Servicos.dll" />
-		<file src="..\..\MDFe.Utils\bin\Release\net6.0\MDFe.Utils.dll" target="lib/net6.0/MDFe.Utils.dll" />
-		<file src="..\..\MDFe.Wsdl\bin\Release\net6.0\MDFe.Wsdl.dll" target="lib/net6.0/MDFe.Wsdl.dll" />
+		<file src="..\..\DFe.Classes\bin\Release\net8.0\DFe.Classes.dll" target="lib/net8.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net8.0\DFe.Utils.dll" target="lib/net8.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net8.0\DFe.Wsdl.dll" target="lib/net8.0/DFe.Wsdl.dll" />
+		<file src="..\..\MDFe.Classes\bin\Release\net8.0\MDFe.Classes.dll" target="lib/net8.0/MDFe.Classes.dll" />
+		<file src="..\..\MDFe.Servicos\bin\Release\net8.0\MDFe.Servicos.dll" target="lib/net8.0/MDFe.Servicos.dll" />
+		<file src="..\..\MDFe.Utils\bin\Release\net8.0\MDFe.Utils.dll" target="lib/net8.0/MDFe.Utils.dll" />
+		<file src="..\..\MDFe.Wsdl\bin\Release\net8.0\MDFe.Wsdl.dll" target="lib/net8.0/MDFe.Wsdl.dll" />
+		
+		<file src="..\..\DFe.Classes\bin\Release\net9.0\DFe.Classes.dll" target="lib/net9.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net9.0\DFe.Utils.dll" target="lib/net9.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net9.0\DFe.Wsdl.dll" target="lib/net9.0/DFe.Wsdl.dll" />
+		<file src="..\..\MDFe.Classes\bin\Release\net9.0\MDFe.Classes.dll" target="lib/net9.0/MDFe.Classes.dll" />
+		<file src="..\..\MDFe.Servicos\bin\Release\net9.0\MDFe.Servicos.dll" target="lib/net9.0/MDFe.Servicos.dll" />
+		<file src="..\..\MDFe.Utils\bin\Release\net9.0\MDFe.Utils.dll" target="lib/net9.0/MDFe.Utils.dll" />
+		<file src="..\..\MDFe.Wsdl\bin\Release\net9.0\MDFe.Wsdl.dll" target="lib/net9.0/MDFe.Wsdl.dll" />
 
 		<file src="..\..\DFe.Classes\bin\Release\net462\DFe.Classes.dll" target="lib/net462/DFe.Classes.dll" />
 		<file src="..\..\DFe.Utils\bin\Release\net462\DFe.Utils.dll" target="lib/net462/DFe.Utils.dll" />

--- a/NuGet/Hercules.NET.NFe.NFCe.Danfe.OpenFastReport/Hercules.NET.NFe.NFCe.Danfe.OpenFastReport.nuspec
+++ b/NuGet/Hercules.NET.NFe.NFCe.Danfe.OpenFastReport/Hercules.NET.NFe.NFCe.Danfe.OpenFastReport.nuspec
@@ -22,8 +22,14 @@
 			<dependency id="FastReport.OpenSource.Export.PdfSimple" version="2019.3.19" />
 		  </group>
 
-		  <group targetFramework="net6.0">
-			<dependency id="System.Drawing.Common" version="6.0.0" />
+		  <group targetFramework="net8.0">
+			<dependency id="System.Drawing.Common" version="8.0.0" />
+			<dependency id="FastReport.OpenSource" version="2019.3.19" />
+			<dependency id="FastReport.OpenSource.Export.PdfSimple" version="2019.3.19" />
+		  </group>
+		  
+		  <group targetFramework="net9.0">
+			<dependency id="System.Drawing.Common" version="9.0.0" />
 			<dependency id="FastReport.OpenSource" version="2019.3.19" />
 			<dependency id="FastReport.OpenSource.Export.PdfSimple" version="2019.3.19" />
 		  </group>
@@ -48,15 +54,25 @@
 		<file src="..\..\NFe.Danfe.Base\bin\Release\netstandard2.0\NFe.Danfe.Base.dll" target="lib/netstandard2.0/NFe.Danfe.Base.dll" />
 		<file src="..\..\NFe.Danfe.Fast\bin\Release\netstandard2.0\NFe.Danfe.Fast.dll" target="lib/netstandard2.0/NFe.Danfe.Fast.dll" />
 		
-		<file src="..\..\DFe.Classes\bin\Release\net6.0\DFe.Classes.dll" target="lib/net6.0/DFe.Classes.dll" />
-		<file src="..\..\DFe.Utils\bin\Release\net6.0\DFe.Utils.dll" target="lib/net6.0/DFe.Utils.dll" />
-		<file src="..\..\DFe.Wsdl\bin\Release\net6.0\DFe.Wsdl.dll" target="lib/net6.0/DFe.Wsdl.dll" />
-		<file src="..\..\NFe.Classes\bin\Release\net6.0\NFe.Classes.dll" target="lib/net6.0/NFe.Classes.dll" />
-		<file src="..\..\NFe.Utils\bin\Release\net6.0\NFe.Utils.dll" target="lib/net6.0/NFe.Utils.dll" />
-		<file src="..\..\NFe.Wsdl.Standard\bin\Release\net6.0\NFe.Wsdl.Standard.dll" target="lib/net6.0/NFe.Wsdl.Standard.dll" />
-		<file src="..\..\NFe.Servicos\bin\Release\net6.0\NFe.Servicos.dll" target="lib/net6.0/NFe.Servicos.dll" />
-		<file src="..\..\NFe.Danfe.Base\bin\Release\net6.0\NFe.Danfe.Base.dll" target="lib/net6.0/NFe.Danfe.Base.dll" />
-		<file src="..\..\NFe.Danfe.Fast\bin\Release\net6.0\NFe.Danfe.Fast.dll" target="lib/net6.0/NFe.Danfe.Fast.dll" />
+		<file src="..\..\DFe.Classes\bin\Release\net8.0\DFe.Classes.dll" target="lib/net8.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net8.0\DFe.Utils.dll" target="lib/net8.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net8.0\DFe.Wsdl.dll" target="lib/net8.0/DFe.Wsdl.dll" />
+		<file src="..\..\NFe.Classes\bin\Release\net8.0\NFe.Classes.dll" target="lib/net8.0/NFe.Classes.dll" />
+		<file src="..\..\NFe.Utils\bin\Release\net8.0\NFe.Utils.dll" target="lib/net8.0/NFe.Utils.dll" />
+		<file src="..\..\NFe.Wsdl.Standard\bin\Release\net8.0\NFe.Wsdl.Standard.dll" target="lib/net8.0/NFe.Wsdl.Standard.dll" />
+		<file src="..\..\NFe.Servicos\bin\Release\net8.0\NFe.Servicos.dll" target="lib/net8.0/NFe.Servicos.dll" />
+		<file src="..\..\NFe.Danfe.Base\bin\Release\net8.0\NFe.Danfe.Base.dll" target="lib/net8.0/NFe.Danfe.Base.dll" />
+		<file src="..\..\NFe.Danfe.Fast\bin\Release\net8.0\NFe.Danfe.Fast.dll" target="lib/net8.0/NFe.Danfe.Fast.dll" />
+		
+		<file src="..\..\DFe.Classes\bin\Release\net9.0\DFe.Classes.dll" target="lib/net9.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net9.0\DFe.Utils.dll" target="lib/net9.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net9.0\DFe.Wsdl.dll" target="lib/net9.0/DFe.Wsdl.dll" />
+		<file src="..\..\NFe.Classes\bin\Release\net9.0\NFe.Classes.dll" target="lib/net9.0/NFe.Classes.dll" />
+		<file src="..\..\NFe.Utils\bin\Release\net9.0\NFe.Utils.dll" target="lib/net9.0/NFe.Utils.dll" />
+		<file src="..\..\NFe.Wsdl.Standard\bin\Release\net9.0\NFe.Wsdl.Standard.dll" target="lib/net9.0/NFe.Wsdl.Standard.dll" />
+		<file src="..\..\NFe.Servicos\bin\Release\net9.0\NFe.Servicos.dll" target="lib/net9.0/NFe.Servicos.dll" />
+		<file src="..\..\NFe.Danfe.Base\bin\Release\net9.0\NFe.Danfe.Base.dll" target="lib/net9.0/NFe.Danfe.Base.dll" />
+		<file src="..\..\NFe.Danfe.Fast\bin\Release\net9.0\NFe.Danfe.Fast.dll" target="lib/net9.0/NFe.Danfe.Fast.dll" />
 		
 		<file src="..\..\DFe.Classes\bin\Release\net45\DFe.Classes.dll" target="lib/net45/DFe.Classes.dll" />
 		<file src="..\..\DFe.Utils\bin\Release\net45\DFe.Utils.dll" target="lib/net45/DFe.Utils.dll" />

--- a/NuGet/Hercules.NET.NFe.NFCe/Hercules.NET.NFe.NFCe.csproj
+++ b/NuGet/Hercules.NET.NFe.NFCe/Hercules.NET.NFe.NFCe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net462;netstandard2.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.NFe.NFCe/Hercules.NET.NFe.NFCe.nuspec
+++ b/NuGet/Hercules.NET.NFe.NFCe/Hercules.NET.NFe.NFCe.nuspec
@@ -24,13 +24,21 @@
 		<file src="..\..\NFe.Utils\bin\Release\netstandard2.0\NFe.Utils.dll" target="lib/netstandard2.0/NFe.Utils.dll" />
 		<file src="..\..\NFe.Wsdl.Standard\bin\Release\netstandard2.0\NFe.Wsdl.Standard.dll" target="lib/netstandard2.0/NFe.Wsdl.Standard.dll" />
 		
-		<file src="..\..\DFe.Classes\bin\Release\net6.0\DFe.Classes.dll" target="lib/net6.0/DFe.Classes.dll" />
-		<file src="..\..\DFe.Utils\bin\Release\net6.0\DFe.Utils.dll" target="lib/net6.0/DFe.Utils.dll" />
-		<file src="..\..\DFe.Wsdl\bin\Release\net6.0\DFe.Wsdl.dll" target="lib/net6.0/DFe.Wsdl.dll" />
-		<file src="..\..\NFe.Classes\bin\Release\net6.0\NFe.Classes.dll" target="lib/net6.0/NFe.Classes.dll" />
-		<file src="..\..\NFe.Servicos\bin\Release\net6.0\NFe.Servicos.dll" target="lib/net6.0/NFe.Servicos.dll" />
-		<file src="..\..\NFe.Utils\bin\Release\net6.0\NFe.Utils.dll" target="lib/net6.0/NFe.Utils.dll" />
-		<file src="..\..\NFe.Wsdl.Standard\bin\Release\net6.0\NFe.Wsdl.Standard.dll" target="lib/net6.0/NFe.Wsdl.Standard.dll" />
+		<file src="..\..\DFe.Classes\bin\Release\net8.0\DFe.Classes.dll" target="lib/net8.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net8.0\DFe.Utils.dll" target="lib/net8.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net8.0\DFe.Wsdl.dll" target="lib/net8.0/DFe.Wsdl.dll" />
+		<file src="..\..\NFe.Classes\bin\Release\net8.0\NFe.Classes.dll" target="lib/net8.0/NFe.Classes.dll" />
+		<file src="..\..\NFe.Servicos\bin\Release\net8.0\NFe.Servicos.dll" target="lib/net8.0/NFe.Servicos.dll" />
+		<file src="..\..\NFe.Utils\bin\Release\net8.0\NFe.Utils.dll" target="lib/net8.0/NFe.Utils.dll" />
+		<file src="..\..\NFe.Wsdl.Standard\bin\Release\net8.0\NFe.Wsdl.Standard.dll" target="lib/net8.0/NFe.Wsdl.Standard.dll" />
+
+		<file src="..\..\DFe.Classes\bin\Release\net9.0\DFe.Classes.dll" target="lib/net9.0/DFe.Classes.dll" />
+		<file src="..\..\DFe.Utils\bin\Release\net9.0\DFe.Utils.dll" target="lib/net9.0/DFe.Utils.dll" />
+		<file src="..\..\DFe.Wsdl\bin\Release\net9.0\DFe.Wsdl.dll" target="lib/net9.0/DFe.Wsdl.dll" />
+		<file src="..\..\NFe.Classes\bin\Release\net9.0\NFe.Classes.dll" target="lib/net9.0/NFe.Classes.dll" />
+		<file src="..\..\NFe.Servicos\bin\Release\net9.0\NFe.Servicos.dll" target="lib/net9.0/NFe.Servicos.dll" />
+		<file src="..\..\NFe.Utils\bin\Release\net9.0\NFe.Utils.dll" target="lib/net9.0/NFe.Utils.dll" />
+		<file src="..\..\NFe.Wsdl.Standard\bin\Release\net9.0\NFe.Wsdl.Standard.dll" target="lib/net9.0/NFe.Wsdl.Standard.dll" />
 		
 		<file src="..\..\DFe.Classes\bin\Release\net462\DFe.Classes.dll" target="lib/net462/DFe.Classes.dll" />
 		<file src="..\..\DFe.Utils\bin\Release\net462\DFe.Utils.dll" target="lib/net462/DFe.Utils.dll" />


### PR DESCRIPTION
- adicionado suporte especifico para .net 8 e 9
- retirado suporte .net 6 (da pra usar ainda, mas vai pegar os pacotes do hercules em .net standard como referencia)
- mantido .net framework e .net standard (sem nenhuma modificação, nem mesmo na arvore de chamadas teve modificação)
- [melhoria no algoritmo de ssl](https://github.com/Hercules-NET/ZeusFiscal/commit/eae33220c260be85ea94d1a3c729b51bbcb5ae69)
- [atualizado projetos danfe para .net 9](https://github.com/Hercules-NET/ZeusFiscal/commit/9710aea01a6f0da1ae3a7b1620088c058891b6ea)

@robertorp usei seu novo [RequestSefazHttpClientHandler.cs](https://github.com/Hercules-NET/ZeusFiscal/compare/master...bredassistemas:ZeusFiscal:master?expand=1#diff-0a76fdfb65a07aeda54edba78e2e51a18ad49662f415707babf3af68846af250) WebRequest, HttpWebRequest, ServicePoint, and WebClient foi **[DESCONTINUADO](
https://learn.microsoft.com/en-us/dotnet/api/system.net.servicepoint?view=net-9.0
)**, no .net 9... ta na hora de migrar pra HttpClient  👍
PARA .net 9 utiliza o [RequestSefazHttpClientHandler.cs](https://github.com/Hercules-NET/ZeusFiscal/compare/master...bredassistemas:ZeusFiscal:master?expand=1#diff-0a76fdfb65a07aeda54edba78e2e51a18ad49662f415707babf3af68846af250) como DEFAULT.