### PR TITLE
Correção gCred

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/gCred.cs
+++ b/NFe.Classes/Informacoes/Detalhe/gCred.cs
@@ -30,12 +30,12 @@
 
         public bool ShouldSerializepCredPresumido()
         {
-            return _pCredPresumido.HasValue && _pCredPresumido > 0;
+            return _pCredPresumido.HasValue;
         }
 
         public bool ShouldSerializevCredPresumido()
         {
-            return _vCredPresumido.HasValue && _vCredPresumido > 0;
+            return _vCredPresumido.HasValue;
         }
     }
 }


### PR DESCRIPTION
- Ato DIAT 11/2025 passa a permitir o envio das tags pCredPresumido e vCredPresumido com valores zerados. Atualmente a tag não é enviada, o que resulta em falha no schema.