### PR TITLE
Alteração da URL do QrCode para CT-e na UF de Minas Gerais

### DIFF
--- a/CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
+++ b/CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
@@ -236,7 +236,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                             CteStatusServico = @"https://cte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4",
                             CteRecepcaoOs = @"https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoOSV4",
                             CteRecepcaoGtve = @"https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoGTVeV4",
-                            QrCode = @"https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml"
+                            QrCode = @"https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml"
                         };
                     }
 
@@ -248,7 +248,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CteInutilizacao = @"https://cte.fazenda.mg.gov.br/cte/services/CteInutilizacao",
                         CteRecepcaoEvento = @"https://cte.fazenda.mg.gov.br/cte/services/RecepcaoEvento",
                         CteConsulta = @"https://cte.fazenda.mg.gov.br/cte/services/CteConsulta",
-                        QrCode = @"https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml",
+                        QrCode = @"https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml",
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.PR:
@@ -455,7 +455,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                             CteStatusServico = @"https://hcte.fazenda.mg.gov.br/cte/services/CTeStatusServicoV4",
                             CteRecepcaoOs = @"https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoOSV4",
                             CteRecepcaoGtve = @"https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoGTVeV4",
-                            QrCode = @"https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml"
+                            QrCode = @"https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml"
                         };
                     }
 


### PR DESCRIPTION
Foi alterado a URL do QrCode para CT-e e na UF de Minas Gerais


- Url antiga: Funcionou até o dia 23/04/2025 
https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml

- Url nova: A partir de 24/04/2025 passa a ser aceita somente esse URL.
https://portalcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml

Mais detalhes da alteração e fonte do problema eu descrivi na issue #64.

Conforme comentado na issue não conseguimos testar em produção a alteração, então se alguem conseguir avisa la na issue por favor ai auxilia para os ADMs caso eles precisam.