### PR TITLE
Melhora no ValidacaoSchemaException

### DIFF
--- a/NFe.Utils/Excecoes/ValidacaoSchemaException.cs
+++ b/NFe.Utils/Excecoes/ValidacaoSchemaException.cs
@@ -15,6 +15,12 @@ namespace NFe.Utils.Excecoes
         /// Houve erros de validação de schema XSD
         /// </summary>
         /// <param name="message"></param>
-        public ValidacaoSchemaException(string message) : base(string.Format("Erros na validação:\n {0}", message)) {}
+        public ValidacaoSchemaException(string message, string xmlString) : base(
+            $"Erros na validação:\n {message}")
+        {
+            XmlString = xmlString;
+        }
+
+        public string XmlString { get; private set; }
     }
 }

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -172,7 +172,7 @@ namespace NFe.Utils.Validacao
             }
 
             if (falhas.Length > 0)
-                throw new ValidacaoSchemaException($"Ocorreu o seguinte erro durante a validação XML: {Environment.NewLine}{falhas}");
+                throw new ValidacaoSchemaException($"Ocorreu o seguinte erro durante a validação XML: {Environment.NewLine}{falhas}", stringXml);
 
             return falhas.ToString().Trim().Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
         }


### PR DESCRIPTION
### Introdução
Ao realizar validação do schema do xml, por vezes não é possível ter acesso ao xml gerado para podermos revisar, o que nos resta seria remover o pacote nuget temporariamente e subir o projeto zeus no nosso projeto. Isso é por vezes necessário, porém burocrático e pouco eficiente. 

### O que foi feito

Por esse motivo, eu resolvi criar o atributo `XmlString `no `ValidacaoSchemaException`. Isso traz uma vantagem no momento de realizar algumas chamadas que não temos o poder de montar o xml para envio. 

### Exemplo de problema causado

Para exemplificar, eu tive um problema ao realizar um cancelamento de nota ao chamar o método `servicoNFe.RecepcaoEventoCancelamento(1, 1, protocolo, chaveNFe, justificativa, cpfCnpj);`

O xml de envio de cancelamento é montado internamente e não temos acesso ao que foi gerado para conferir possíveis inconsistências. 

### Solução
Com essa mudança, caso qualquer validação de schema falhe, o xml com falhas virá junto ao ValidacaoSchemaException, facilitando o debug para correções de problemas sem a necessidade de referenciar o projeto diretamente.

### Como utilizar

```
try 
{
   servicoNFe.RecepcaoEventoCancelamento(1, 1, protocolo, chaveNFe, justificativa, cpfCnpj);
}
catch(ValidacaoSchemaException vsex) 
{
   //tenho acesso ao xml através desse atributo: 
   vsex.XmlString
}
```

### Objetivo final
Facilitar o debug da aplicação sem a necessidade de referenciar o projeto Zeus Fiscal no meu projeto para essa situação

