### PR TITLE
Suporte a QR-CODE versão 3.0 da NT2025.001

### DIFF
--- a/NFe.Utils/Enums.cs
+++ b/NFe.Utils/Enums.cs
@@ -17,6 +17,10 @@ namespace NFe.Utils
         QrCodeVersao1 = 100,
 
         [Description("Versão 2.0 do QR-Code")]
-        QrCodeVersao2 = 2
+        QrCodeVersao2 = 2,
+
+        [Description("Versão 3.0 do QR-Code")]
+        QrCodeVersao3 = 3,
+
     }
 }

--- a/NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
+++ b/NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
@@ -94,7 +94,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.RR, versao3E4, "https://www.sefaz.rr.gov.br/nfce/servlet/qrcode"},
                 {Estado.MG, versao3E4, "https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml"}
             };
-            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao1, VersaoQrCode.QrCodeVersao2 }, urlsQrCodeProducaoQrCode1E2);
+            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao1, VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsQrCodeProducaoQrCode1E2);
 
             var urlsQrCodeProducaoQrCode1 = new TupleList<Estado, VersaoServico[], string>
             {
@@ -116,7 +116,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.TO, versao4, "http://apps.sefaz.to.gov.br/portal-nfce/qrcodeNFCe"},
                 {Estado.SC, versao4, "https://sat.sef.sc.gov.br/nfce/consulta"}
             };
-            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao2 }, urlsQrCodeProducaoQrCode2);
+            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsQrCodeProducaoQrCode2);
 
             #endregion
 
@@ -148,7 +148,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.TO, versao3E4, "http://apps.sefaz.to.gov.br/portal-nfce-homologacao/qrcodeNFCe"},
                 {Estado.MG, versao3E4, "https://portalsped.fazenda.mg.gov.br/portalnfce/sistema/qrcode.xhtml"}
             };
-            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao1, VersaoQrCode.QrCodeVersao2 }, urlsQrCodeHomologacaoQrCode1E2);
+            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao1, VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsQrCodeHomologacaoQrCode1E2);
 
             var urlsQrCodeHomologacaoQrCode1 = new TupleList<Estado, VersaoServico[], string>
             {
@@ -166,7 +166,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.SP, versao4, "https://www.homologacao.nfce.fazenda.sp.gov.br/qrcode"},
                 {Estado.SC, versao4, "https://hom.sat.sef.sc.gov.br/nfce/consulta"},
             };
-            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao2 }, urlsQrCodeHomologacaoQrCode2);
+            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlQrCode, new[] { VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsQrCodeHomologacaoQrCode2);
 
             #endregion
 
@@ -273,8 +273,8 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.RR, versao3E4, "www.sefaz.rr.gov.br/nfce/consulta"}
             };
 
-            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2 }, urlsConsultaHomologacaoEProducao2);
-            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2 }, urlsConsultaHomologacaoEProducao2);
+            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsConsultaHomologacaoEProducao2);
+            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsConsultaHomologacaoEProducao2);
 
             #endregion
 
@@ -293,7 +293,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.SC, versao3E4, "https://sat.sef.sc.gov.br/nfce/consulta" }
             };
 
-            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2 }, urlsConsultaProducao2);
+            adicionarUrls(TipoAmbiente.Producao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsConsultaProducao2);
 
             #endregion
 
@@ -312,7 +312,7 @@ namespace NFe.Utils.InformacoesSuplementares
                 {Estado.SC, versao3E4, "https://hom.sat.sef.sc.gov.br/nfce/consulta" }
             };
 
-            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2 }, urlsConsultaHomologacao2);
+            adicionarUrls(TipoAmbiente.Homologacao, TipoUrlConsultaPublica.UrlConsulta, new[] { VersaoQrCode.QrCodeVersao2, VersaoQrCode.QrCodeVersao3 }, urlsConsultaHomologacao2);
 
             #endregion
 
@@ -372,6 +372,8 @@ namespace NFe.Utils.InformacoesSuplementares
                     return ObterUrlQrCode1(infNFeSupl, nfe, cIdToken, csc, versaoServico);
                 case VersaoQrCode.QrCodeVersao2:
                     return ObterUrlQrCode2(infNFeSupl, nfe, cIdToken, csc, versaoServico);
+                case VersaoQrCode.QrCodeVersao3:
+                    return ObterUrlQrCode3(infNFeSupl, nfe, versaoServico);
                 default:
                     throw new ArgumentOutOfRangeException("versaoQrCode", versaoQrCode, null);
             }
@@ -397,7 +399,7 @@ namespace NFe.Utils.InformacoesSuplementares
             if (nfe.infNFe.dest != null)
                 cDest = "&cDest=" + nfe.infNFe.dest.CPF + nfe.infNFe.dest.CNPJ + nfe.infNFe.dest.idEstrangeiro;
 
-            //Passo 3: Substituir os valores (“dhEmi” e “digVal”) nos parâmetros;
+            //Passo 3: Substituir os valores ("dhEmi" e "digVal") nos parâmetros;
             var dadosBase =
                 "chNFe=" + nfe.infNFe.Id.Substring(3) +
                 "&nVersao=100" +
@@ -485,6 +487,75 @@ namespace NFe.Utils.InformacoesSuplementares
             if (!url.EndsWith(parametro))
                 url += parametro;
             return url;
+        }
+
+        /// <summary>
+        /// Obtém a URL para uso no QR-Code, versão 3.0 - leiaute 4.00+
+        /// </summary>
+        private static string ObterUrlQrCode3(infNFeSupl infNFeSupl, Classes.NFe nfe, VersaoServico versaoServico)
+        {
+            const string pipe = "|";
+
+            // Chave de Acesso da NFC-e
+            var chave = nfe.infNFe.Id.Substring(3);
+            // Versão do QR-Code
+            var versaoQrCode = 3;
+            // Identificação do Ambiente (1 – Produção, 2 – Homologação)
+            var ambiente = (int)nfe.infNFe.ide.tpAmb;
+
+            // Monta os parâmetros base
+            var dadosBase = string.Concat(
+                chave, pipe,
+                versaoQrCode, pipe,
+                ambiente
+            );
+
+            if (nfe.infNFe.ide.tpEmis == TipoEmissao.teOffLine)
+            {
+                // Dia da emissão
+                var diaEmi = nfe.infNFe.ide.dhEmi.Day.ToString("D2");
+                // Valor total da NFC-e
+                var valorNfce = nfe.infNFe.total.ICMSTot.vNF.ToString("0.00").Replace(',', '.');
+
+                // tp_idDest e idDest
+                string tp_idDest = string.Empty;
+                string idDest = string.Empty;
+                if (nfe.infNFe.dest != null)
+                {
+                    if (!string.IsNullOrEmpty(nfe.infNFe.dest.idEstrangeiro))
+                    {
+                        tp_idDest = "3";
+                        idDest = nfe.infNFe.dest.idEstrangeiro.Trim();
+                    }
+                    else if (!string.IsNullOrEmpty(nfe.infNFe.dest.CPF) && nfe.infNFe.dest.CPF.Length == 11)
+                    {
+                        tp_idDest = "2";
+                        idDest = nfe.infNFe.dest.CPF.Replace(".", "").Replace("/", "").Replace("-", "").Trim();
+                    }
+                    else if (!string.IsNullOrEmpty(nfe.infNFe.dest.CNPJ) && nfe.infNFe.dest.CNPJ.Length == 14)
+                    {
+                        tp_idDest = "1";
+                        idDest = nfe.infNFe.dest.CNPJ.Replace(".", "").Replace("/", "").Replace("-", "").Trim();
+                    }
+                }
+
+                // Monta os parâmetros base
+                dadosBase = string.Concat(dadosBase, pipe,
+                  diaEmi, pipe,
+                  valorNfce, pipe,
+                  tp_idDest, pipe,
+                  idDest
+                );
+
+                // Assinatura SHA-1 dos parâmetros + CSC
+                var assinatura = Conversao.ObterHexSha1DeString(dadosBase);
+                dadosBase = string.Concat(dadosBase, pipe, assinatura);
+            }
+
+            var url = ObterUrlQrCode2ComParametro(infNFeSupl, nfe.infNFe.ide.tpAmb, nfe.infNFe.ide.cUF, versaoServico);
+
+            // Monta a URL base
+            return string.Concat(url, "?p=", dadosBase);
         }
     }
 }


### PR DESCRIPTION
Implementa a nota URL do QRCODE versão 3.0 que entrou em homologação 01/06/2025.
Não consegui testar, acho que a SEFAZ RS ainda esta implementando isso.
Mas não deve quebrar caso ainda usem o QRCODE 2.0