### PR TITLE
Adicionar método GetIcmsStValue para ICMSBasico

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Extensions.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Extensions.cs
@@ -47,6 +47,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
             return GetPropDecimalValue(icms, "vICMS");
         }
 
+        public static decimal GetIcmsStValue(this ICMSBasico icms)
+        {
+            return GetPropDecimalValue(icms, "vICMSST");
+        }
+
         public static decimal GetIpiPercent(this IPIBasico ipi)
         {
             return GetPropDecimalValue(ipi, "pIPI");


### PR DESCRIPTION
Foi adicionado um novo método chamado `GetIcmsStValue` à classe de extensões. Este método calcula e retorna o valor do ICMS ST (vICMSST) a partir de um objeto do tipo `ICMSBasico`, utilizando a função `GetPropDecimalValue` para obter o valor correspondente.