### PR TITLE
NT 2020.005 v1.21 - nAdicao opcional em caso de DUIMP

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/DeclaracaoImportacao/adi.cs
+++ b/NFe.Classes/Informacoes/Detalhe/DeclaracaoImportacao/adi.cs
@@ -7,7 +7,12 @@ namespace NFe.Classes.Informacoes.Detalhe.DeclaracaoImportacao
         /// <summary>
         ///     I26 - Numero da Adição
         /// </summary>
-        public int nAdicao { get; set; }
+        public int? nAdicao { get; set; }
+
+        public bool ShouldSerializenAdicao()
+        {
+            return nAdicao.HasValue;
+        }
 
         /// <summary>
         ///     I27 - Numero sequencial do item dentro da Adição


### PR DESCRIPTION
Ajustado campo adi > nAdicao para nulável, conforme NT 2020.005 v1.21.
Em caso de Duimp esse campo não deverá ser preenchido.

<img width="1032" height="65" alt="image" src="https://github.com/user-attachments/assets/25da8e32-ced7-4921-a0e1-f84ab2536d51" />

Testado em Homologação, nota autorizada com sucesso.