### PR TITLE
Tornar vTotTrib (W16a) nullable para se adequar ao manual

### DIFF
--- a/NFe.Classes/Informacoes/Total/ICMSTot.cs
+++ b/NFe.Classes/Informacoes/Total/ICMSTot.cs
@@ -17,7 +17,7 @@ namespace NFe.Classes.Informacoes.Total
         private decimal _vCofins;
         private decimal _vOutro;
         private decimal _vNf;
-        private decimal _vTotTrib;
+        private decimal? _vTotTrib;
         private decimal? _vFcpufDest;
         private decimal? _vIcmsufDest;
         private decimal? _vIcmsufRemet;
@@ -361,11 +361,15 @@ namespace NFe.Classes.Informacoes.Total
         /// <summary>
         ///     W16a - Valor aproximado total de tributos federais, estaduais e municipais.
         /// </summary>
-        public decimal vTotTrib
+        public decimal? vTotTrib
         {
             get { return _vTotTrib.Arredondar(2); }
             set { _vTotTrib = value.Arredondar(2); }
         }
 
+        public bool ShouldSerializevTotTrib()
+        {
+            return vTotTrib.HasValue;
+        }
     }
 }

--- a/NFe.Danfe.Base/NFCe/NFCe.frx
+++ b/NFe.Danfe.Base/NFCe/NFCe.frx
@@ -16,7 +16,7 @@ using FastReport.Utils;
 using NFe.Classes.Informacoes.Pagamento;
 using NFe.Utils;
 using DFe.Utils;
-using NFe.Classes.Informacoes.Destinatario;  
+using NFe.Classes.Informacoes.Destinatario;
 using NFe.Classes.Informacoes.Identificacao.Tipos;
 using DFe.Classes.Flags;
 using NFe.Danfe.Base;
@@ -28,13 +28,13 @@ namespace FastReport
 {
   public class ReportScript
   {
-    
+
     private void txtDescPagto_BeforePrint(object sender, EventArgs e)
     {
       if(Report.GetColumnValue(&quot;NFCe.NFe.infNFe.pag.tPag&quot;) != null)
-        txtDescPagto.Text = ((FormaPagamento)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.pag.tPag&quot;)).Descricao();                            
+        txtDescPagto.Text = ((FormaPagamento)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.pag.tPag&quot;)).Descricao();
     }
-    
+
     private void txtDescDetPagto_BeforePrint(object sender, EventArgs e)
     {
       if(Report.GetDataSource(&quot;NFCe.NFe.infNFe.pag.detPag&quot;).RowCount != 0 &amp;&amp; Report.GetColumnValue(&quot;NFCe.NFe.infNFe.pag.detPag.tPag&quot;) != null)
@@ -43,75 +43,75 @@ namespace FastReport
 
     private void txtEmitCnpj_BeforePrint(object sender, EventArgs e)
     {
-      var cnpj = (string)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.emit.CNPJ&quot;); 
+      var cnpj = (string)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.emit.CNPJ&quot;);
       if (!string.IsNullOrEmpty(cnpj))
         txtEmitCnpj.Text = &quot;CNPJ: &quot; + String.Format(@&quot;{0:00\.000\.000\/0000\-00}&quot;, long.Parse(cnpj));
     }
 
     private void memChaveNfe_BeforePrint(object sender, EventArgs e)
-    {       
+    {
       var chave = Substring( ((String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.Id&quot;)), 3);
       if (!string.IsNullOrEmpty(chave) &amp; chave.Length == 44)
       {
         var chaveFormatada = &quot;&quot;;
-        for (int i = 0; i &lt; chave.Length; i += 4)  
-          chaveFormatada = chaveFormatada + chave.Substring(i, 4) + &quot; &quot;;       
-        memChaveNfe.Text = chaveFormatada;      
-      }                                               
+        for (int i = 0; i &lt; chave.Length; i += 4)
+          chaveFormatada = chaveFormatada + chave.Substring(i, 4) + &quot; &quot;;
+        memChaveNfe.Text = chaveFormatada;
+      }
     }
 
     private void Destinatario_BeforePrint(object sender, EventArgs e)
-    {    
+    {
       TrataCamposDestinatario();
       dbDestinatario.Visible = ((NfceLayoutQrCode) Report.GetParameterValue(&quot;NfceLayoutQrCode&quot;) == NfceLayoutQrCode.Abaixo);
     }
-    
+
     private void TrataCamposDestinatario(){
       if ( ((dest)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest&quot;)) == null ) //Destinatário não informado
       {
         txtConsumidor.Text = &quot;CONSUMIDOR NÃO IDENTIFICADO&quot;;
-        txtConsumidor2.Text = txtConsumidor.Text;        
+        txtConsumidor2.Text = txtConsumidor.Text;
         txtDestEndereco.Text = &quot;&quot;;
         txtDestEndereco2.Text = txtDestEndereco.Text;
         txtDestNome.Text = &quot;&quot;;
         txtDestNome2.Text = txtDestNome.Text;
       }
       else
-      {                                                
+      {
         txtDestNome.Text = ObterDocumentoDest() + ((String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.xNome&quot;));
         txtDestNome2.Text = txtDestNome.Text;
-      }   
+      }
       //Endereço do destinatário é opcional para NFCe
-      txtDestEndereco.Visible = ((enderDest)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.enderDest&quot;)) != null;      
+      txtDestEndereco.Visible = ((enderDest)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.enderDest&quot;)) != null;
       txtDestEndereco2.Visible = txtDestEndereco.Visible;
     }
-    
+
     private string ObterDocumentoDest(){
       var documentoDest = &quot;&quot;;
       var cnpj = (String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.CNPJ&quot;);
       var cpf = (String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.CPF&quot;);
       var idEstrangeiro = (String)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.dest.idEstrangeiro&quot;);
-      if ( !String.IsNullOrEmpty(cnpj)) documentoDest = &quot;CNPJ: &quot; + String.Format(@&quot;{0:00\.000\.000\/0000\-00}&quot;, long.Parse(cnpj)) + &quot; &quot;;	 
-      if ( !String.IsNullOrEmpty(cpf)) documentoDest = &quot;CPF: &quot; + String.Format(@&quot;{0:000\.000\.000\-00}&quot;, long.Parse(cpf)) + &quot; &quot;;	 	  
-      if ( !String.IsNullOrEmpty(idEstrangeiro)) documentoDest = &quot;Id. Estrangeiro: &quot; + idEstrangeiro + &quot; &quot;;	 
+      if ( !String.IsNullOrEmpty(cnpj)) documentoDest = &quot;CNPJ: &quot; + String.Format(@&quot;{0:00\.000\.000\/0000\-00}&quot;, long.Parse(cnpj)) + &quot; &quot;;
+      if ( !String.IsNullOrEmpty(cpf)) documentoDest = &quot;CPF: &quot; + String.Format(@&quot;{0:000\.000\.000\-00}&quot;, long.Parse(cpf)) + &quot; &quot;;
+      if ( !String.IsNullOrEmpty(idEstrangeiro)) documentoDest = &quot;Id. Estrangeiro: &quot; + idEstrangeiro + &quot; &quot;;
       return documentoDest;
     }
 
     private void dbProdutosUmaLinha_BeforePrint(object sender, EventArgs e)
     {
       //Conforme Manual de Padrões Padrões Técnicos do DANFE-NFC-e e QR Code, página 8. &quot;No caso de emissão em contingência, é obrigatória a impressão do Detalhe da Venda e do DANFE NFC-e&quot;
-      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal ) 
+      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal )
         dbProdutosUmaLinha.Visible = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.UmaLinha;
       else
         dbProdutosUmaLinha.Visible = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.UmaLinha;
-      
+
       //Mostrar/Ocultar desconto concedido no item
       txtProdutoUmaLinhaValorUnit.Text = &quot;[NFCe.NFe.infNFe.det.prod.vUnCom]&quot;;
       txtProdutoUmaLinhaValorTotal.Text = &quot;[NFCe.NFe.infNFe.det.prod.vProd]&quot;;
       dbProdutosUmaLinha.Border.Lines = BorderLines.Bottom;
       var imprimeDesconto = dbProdutosUmaLinha.Visible &amp; ((Boolean)Report.GetParameterValue(&quot;NfceImprimeDescontoItem&quot;)) &amp;
-        ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.det.prod.vDesc&quot;)) &gt; 0;      
-      cbDescontoItemUmaLinha.Visible = imprimeDesconto;  
+        ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.det.prod.vDesc&quot;)) &gt; 0;
+      cbDescontoItemUmaLinha.Visible = imprimeDesconto;
       if (imprimeDesconto)
         dbProdutosUmaLinha.Border.Lines = BorderLines.None;
     }
@@ -119,45 +119,45 @@ namespace FastReport
     private void ghbProdutosDuasLinhas_BeforePrint(object sender, EventArgs e)
     {
       //Conforme Manual de Padrões Padrões Técnicos do DANFE-NFC-e e QR Code, página 8. &quot;No caso de emissão em contingência, é obrigatória a impressão do Detalhe da Venda e do DANFE NFC-e&quot;
-      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal ) 
-        ghbProdutosDuasLinhas.Visible = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.DuasLinhas || 
+      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal )
+        ghbProdutosDuasLinhas.Visible = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.DuasLinhas ||
                                         ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.Completo;
       else
-        ghbProdutosDuasLinhas.Visible = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.DuasLinhas || 
+        ghbProdutosDuasLinhas.Visible = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.DuasLinhas ||
                                         ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.Completo;
     }
-    
+
     private void dbProdutosDuasLinhas_BeforePrint(object sender, EventArgs e)
     {
       //Conforme Manual de Padrões Padrões Técnicos do DANFE-NFC-e e QR Code, página 8. &quot;No caso de emissão em contingência, é obrigatória a impressão do Detalhe da Venda e do DANFE NFC-e&quot;
-      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal ) 
-        dbProdutosDuasLinhas.Visible = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.DuasLinhas || 
+      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal )
+        dbProdutosDuasLinhas.Visible = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.DuasLinhas ||
                                        ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.Completo;
       else
-        dbProdutosDuasLinhas.Visible = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.DuasLinhas || 
-                                       ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.Completo;  ;  
-      
+        dbProdutosDuasLinhas.Visible = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.DuasLinhas ||
+                                       ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.Completo;  ;
+
       //Mostrar/Ocultar desconto concedido no item
       txtProdutoDuasLinhasValorUnit.Text = &quot;[NFCe.NFe.infNFe.det.prod.vUnCom]&quot;;
       txtProdutoDuasLinhasValorTotal.Text = &quot;[NFCe.NFe.infNFe.det.prod.vProd]&quot;;
       dbProdutosDuasLinhas.Border.Lines = BorderLines.Bottom;
       var imprimeDesconto = dbProdutosDuasLinhas.Visible &amp; ((Boolean)Report.GetParameterValue(&quot;NfceImprimeDescontoItem&quot;)) &amp;
-        ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.det.prod.vDesc&quot;)) &gt; 0;      
-      cbDescontoItemDuasLinhas.Visible = imprimeDesconto;                                      
+        ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.det.prod.vDesc&quot;)) &gt; 0;
+      cbDescontoItemDuasLinhas.Visible = imprimeDesconto;
       if (imprimeDesconto)
-        dbProdutosDuasLinhas.Border.Lines = BorderLines.None;    
+        dbProdutosDuasLinhas.Border.Lines = BorderLines.None;
       //Se possuir desconto, e estiver configurado para não exibi-lo, exibe os valores líquidos nos campos abaixo:
-      if (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.det.prod.vDesc&quot;)) &gt; 0 &amp; !imprimeDesconto)  
+      if (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.det.prod.vDesc&quot;)) &gt; 0 &amp; !imprimeDesconto)
       {
         txtProdutoDuasLinhasValorUnit.Text = &quot;[([NFCe.NFe.infNFe.det.prod.vProd] - [NFCe.NFe.infNFe.det.prod.vDesc]) / [NFCe.NFe.infNFe.det.prod.qCom]]&quot;;
-        txtProdutoDuasLinhasValorTotal.Text = &quot;[[NFCe.NFe.infNFe.det.prod.vProd] - [NFCe.NFe.infNFe.det.prod.vDesc]]&quot;;        
+        txtProdutoDuasLinhasValorTotal.Text = &quot;[[NFCe.NFe.infNFe.det.prod.vProd] - [NFCe.NFe.infNFe.det.prod.vDesc]]&quot;;
       }
-    }  
+    }
 
     private void ghbProdutosUmaLinha_BeforePrint(object sender, EventArgs e)
     {
       //Conforme Manual de Padrões Padrões Técnicos do DANFE-NFC-e e QR Code, página 8. &quot;No caso de emissão em contingência, é obrigatória a impressão do Detalhe da Venda e do DANFE NFC-e&quot;
-      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal ) 
+      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal )
         ghbProdutosUmaLinha.Visible = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.UmaLinha;
       else
         ghbProdutosUmaLinha.Visible = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.UmaLinha;
@@ -171,8 +171,8 @@ namespace FastReport
       string msgContigencia = &quot;&quot;;
       if ( ((TipoAmbiente)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpAmb&quot;)) == TipoAmbiente.Homologacao )
         msgHomologacao = &quot;EMITIDA EM AMBIENTE DE HOMOLOGAÇÃO – SEM VALOR FISCAL&quot; + Environment.NewLine;
-      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) != TipoEmissao.teNormal ) 
-        msgContigencia = &quot;EMITIDA EM CONTINGÊNCIA&quot; + Environment.NewLine;      
+      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) != TipoEmissao.teNormal )
+        msgContigencia = &quot;EMITIDA EM CONTINGÊNCIA&quot; + Environment.NewLine;
 
       memMsgFiscal.Text = msgHomologacao + msgContigencia + memMsgFiscal.Text;
     }
@@ -186,41 +186,41 @@ namespace FastReport
     private void PgNfce_StartPage(object sender, EventArgs e)
     {
       phbCancelado.Visible = ((Boolean)Report.GetParameterValue(&quot;NfceCancelado&quot;));
-      
-      if (!Engine.FinalPass) 
-        return;       
+
+      if (!Engine.FinalPass)
+        return;
       if ( (NfceModoImpressao) ((Int32)Report.GetParameterValue(&quot;NfceModoImpressao&quot;)) != NfceModoImpressao.UnicaPagina)
-        return;        
-        
-      PgNfce.PaperHeight = 
-        (rtbEmitLogoHeight + 
-         phbEmitenteHeight + 
+        return;
+
+      PgNfce.PaperHeight =
+        (rtbEmitLogoHeight +
+         phbEmitenteHeight +
          ((Boolean)Report.GetParameterValue(&quot;NfceCancelado&quot;) ? phbCancelado.Height : 0)+
-         ghbProdutosUmaLinhaHeight + 
-         dbProdutosUmaLinhaHeight + 
-         ghbProdutosDuasLinhasHeight + 
-         dbProdutosDuasLinhasHeight + 
+         ghbProdutosUmaLinhaHeight +
+         dbProdutosUmaLinhaHeight +
+         ghbProdutosDuasLinhasHeight +
+         dbProdutosDuasLinhasHeight +
          gfbProdutosHeight +
-         dbPagamentoHeight + 
+         dbPagamentoHeight +
          dbDetPagamentoHeight +
-         dbTributosHeight + 
-         dbObservacaoHeight + 
-         dbInfoFiscalHeight + 
+         dbTributosHeight +
+         dbObservacaoHeight +
+         dbInfoFiscalHeight +
          dbNumeroSerieDhHeight +
          dbConsultaHeight +
-         dbDestinatarioHeight + 
+         dbDestinatarioHeight +
          dbQrCodeNormalHeight +
          dbQrCodeLateralHeight +
          dbProtocoloHeigth
         ) /
-        Units.Millimeters + PgNfce.TopMargin + PgNfce.BottomMargin; 
+        Units.Millimeters + PgNfce.TopMargin + PgNfce.BottomMargin;
 
     }
 
     float dbProdutosUmaLinhaHeight;
     private void dbProdutosUmaLinha_AfterPrint(object sender, EventArgs e)
     {
-      dbProdutosUmaLinhaHeight += (dbProdutosUmaLinha.Visible ? dbProdutosUmaLinha.Height : 0) + (cbDescontoItemUmaLinha.Visible ? cbDescontoItemUmaLinha.Height : 0);      
+      dbProdutosUmaLinhaHeight += (dbProdutosUmaLinha.Visible ? dbProdutosUmaLinha.Height : 0) + (cbDescontoItemUmaLinha.Visible ? cbDescontoItemUmaLinha.Height : 0);
     }
 
     float dbProdutosDuasLinhasHeight;
@@ -234,13 +234,13 @@ namespace FastReport
     {
       dbInfoFiscalHeight = (dbInfoFiscal.Visible ? dbInfoFiscal.Height : 0);
     }
-    
+
     float dbNumeroSerieDhHeight;
     private void dbNumeroSerieDh_AfterPrint(object sender, EventArgs e)
     {
       dbNumeroSerieDhHeight = (dbNumeroSerieDh.Visible ? dbNumeroSerieDh.Height : 0);
     }
-    
+
     float dbConsultaHeight;
     private void dbConsulta_AfterPrint(object sender, EventArgs e)
     {
@@ -274,15 +274,15 @@ namespace FastReport
     float gfbProdutosHeight;
     private void gfbProdutos_AfterPrint(object sender, EventArgs e)
     {
-      gfbProdutosHeight = (gfbProdutos.Visible ? gfbProdutos.Height : 0);      
+      gfbProdutosHeight = (gfbProdutos.Visible ? gfbProdutos.Height : 0);
     }
 
     float dbPagamentoHeight;
     private void dbPagamento_AfterPrint(object sender, EventArgs e)
     {
-      dbPagamentoHeight = (dbPagamento.Visible ? dbPagamento.Height : 0);       
+      dbPagamentoHeight = (dbPagamento.Visible ? dbPagamento.Height : 0);
     }
-    
+
     float dbDetPagamentoHeight;
     private void dbDetPagamento_AfterPrint(object sender, EventArgs e)
     {
@@ -316,12 +316,12 @@ namespace FastReport
     private void cbDesconto_BeforePrint(object sender, EventArgs e)
     {
       cbDesconto.Visible = ((Decimal)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.total.ICMSTot.vDesc&quot;)) &gt; 0;
-    }    
+    }
 
     private void txtValorTotal_BeforePrint(object sender, EventArgs e)
     {
       var vServ = ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.total.ISSQNtot.vServ&quot;)) == null ? 0 : ((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.total.ISSQNtot.vServ&quot;));
-      txtValorTotal.Text = (((Decimal)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.total.ICMSTot.vProd&quot;)) + vServ).ToString();      
+      txtValorTotal.Text = (((Decimal)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.total.ICMSTot.vProd&quot;)) + vServ).ToString();
     }
 
     private void dbPagamento_BeforePrint(object sender, EventArgs e)
@@ -333,7 +333,7 @@ namespace FastReport
     {
       dbDetPagamento.Visible = Report.GetDataSource(&quot;NFCe.NFe.infNFe.pag.detPag&quot;).RowCount != 0 &amp;&amp; Report.GetColumnValue(&quot;NFCe.NFe.infNFe.pag.detPag.tPag&quot;) != null;
     }
-	
+
 	private void dbTroco_BeforePrint(object sender, EventArgs e)
     {
       dbTroco.Visible = Report.GetColumnValue(&quot;NFCe.NFe.infNFe.pag.vTroco&quot;) != null;
@@ -343,7 +343,7 @@ namespace FastReport
     private void dbQrCodeLateral_BeforePrint(object sender, EventArgs e)
     {
       TrataCamposDestinatario();
-      dbQrCodeLateral.Visible = ((NfceLayoutQrCode) Report.GetParameterValue(&quot;NfceLayoutQrCode&quot;) == NfceLayoutQrCode.Lateral);        
+      dbQrCodeLateral.Visible = ((NfceLayoutQrCode) Report.GetParameterValue(&quot;NfceLayoutQrCode&quot;) == NfceLayoutQrCode.Lateral);
     }
 
     float dbQrCodeLateralHeight;
@@ -355,7 +355,7 @@ namespace FastReport
     float dbProtocoloHeigth;
     private void dbProtocolo_AfterPrint(object sender, EventArgs e)
     {
-      dbProtocoloHeigth = (dbProtocolo.Visible ? dbProtocolo.Height : 0);      
+      dbProtocoloHeigth = (dbProtocolo.Visible ? dbProtocolo.Height : 0);
     }
 
     private void dbQrCodeNormal_BeforePrint(object sender, EventArgs e)
@@ -370,19 +370,19 @@ namespace FastReport
 
     private void dbNumeroSerieDh_BeforePrint(object sender, EventArgs e)
     {
-      dbNumeroSerieDh.Visible = ((NfceLayoutQrCode) Report.GetParameterValue(&quot;NfceLayoutQrCode&quot;) == NfceLayoutQrCode.Abaixo);      
+      dbNumeroSerieDh.Visible = ((NfceLayoutQrCode) Report.GetParameterValue(&quot;NfceLayoutQrCode&quot;) == NfceLayoutQrCode.Abaixo);
     }
 
     private void txtProdutoDuasLinhasDescricaoProduto_BeforePrint(object sender, EventArgs e)
     {
       bool nfceDetalheVendaNormalCompleto = ((NfceDetalheVendaNormal)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaNormal&quot;))) == NfceDetalheVendaNormal.Completo;
       bool nfceDetalheVendaContingenciaCompleto = ((NfceDetalheVendaContigencia)((Int32)Report.GetParameterValue(&quot;NfceDetalheVendaContigencia&quot;))) == NfceDetalheVendaContigencia.Completo;
-      
-      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal ) 
+
+      if ( ((TipoEmissao)Report.GetColumnValue(&quot;NFCe.NFe.infNFe.ide.tpEmis&quot;)) == TipoEmissao.teNormal )
         txtProdutoDuasLinhasDescricaoProduto.WordWrap = nfceDetalheVendaNormalCompleto;
       else
-        txtProdutoDuasLinhasDescricaoProduto.WordWrap = nfceDetalheVendaContingenciaCompleto;                     
-      
+        txtProdutoDuasLinhasDescricaoProduto.WordWrap = nfceDetalheVendaContingenciaCompleto;
+
       if (nfceDetalheVendaNormalCompleto || nfceDetalheVendaContingenciaCompleto)
         txtProdutoDuasLinhasDescricaoProduto.LineHeight = txtProdutoDuasLinhasDescricaoProduto.Height; // Ajuste de espaçamento entre linhas
     }
@@ -705,7 +705,7 @@ namespace FastReport
               <Column Name="vCOFINS" DataType="System.Decimal"/>
               <Column Name="vOutro" DataType="System.Decimal"/>
               <Column Name="vNF" DataType="System.Decimal"/>
-              <Column Name="vTotTrib" DataType="System.Decimal"/>
+              <Column Name="vTotTrib" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vFCPUFDest" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vICMSUFDest" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vICMSUFRemet" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>

--- a/NFe.Danfe.Base/NFe/NFeEvento.frx
+++ b/NFe.Danfe.Base/NFe/NFeEvento.frx
@@ -29,28 +29,28 @@ namespace FastReport
       {
         case 'c':  //CEP
           if (valor.Length == 8)
-            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);          
+            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);
           break;
-        case 'f':  //Telefone /celular         
+        case 'f':  //Telefone /celular
           if (valor.Length == 10)
             valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,4) + &quot;-&quot; + valor.Substring(6,4);
           else if (valor.Length == 11)
-            valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);          
+            valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);
           break;
         case 'd': //cpf / cnpj
           if (valor.Length == 11)
             valor = valor.Substring(0,3)+&quot;.&quot;+valor.Substring(3,3)+&quot;.&quot;+valor.Substring(6,3)+&quot;-&quot;+valor.Substring(9,2);
           else if (valor.Length == 14)
             valor = valor.Substring(0,2)+&quot;.&quot;+valor.Substring(2,3)+&quot;.&quot;+valor.Substring(5,3)+&quot;/&quot;+valor.Substring(8,4)+&quot;-&quot;+valor.Substring(12,2);
-          break;   
+          break;
         case 'p':
           if (valor.Length == 7)
             valor = valor.Substring(0,3)+&quot;-&quot;+valor.Substring(3,4);
           break;
-      }                               
+      }
       return valor;
     }
-    
+
 
     private void Memo47_BeforePrint(object sender, EventArgs e)
     {
@@ -59,10 +59,10 @@ namespace FastReport
       try {
         var value = (DateTimeOffset)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.dhEmi&quot;);
         Memo49.Text = value.Date.Month.ToString().PadLeft(2, '0')+&quot;/&quot;+value.Date.Year.ToString().PadLeft(4, '0');
-      } catch { 
+      } catch {
       throw new Exception("Erro - dhEmi em formato incorreto.");
       }
-      try { 
+      try {
         Memo53.Text = DateTime.Parse(Report.GetColumnValue(&quot;procEventoNFe.evento.infEvento.dhEvento&quot;).ToString()).ToString();
       } catch{
         Memo53.Text=&quot;&quot;;
@@ -77,7 +77,7 @@ namespace FastReport
         Memo40.Text=&quot;CARTA DE CORREÇÃO ELETRÔNICA&quot;;
         BandCondicoesUso.Visible=true;
       }
-      try { 
+      try {
         Memo60.Text = DateTime.Parse(Report.GetColumnValue(&quot;procEventoNFe.retEvento.infEvento.dhRegEvento&quot;).ToString()).ToString();
       } catch{
         Memo60.Text=&quot;&quot;;
@@ -90,14 +90,14 @@ namespace FastReport
     private void memJustificativaCorrecao_BeforePrint(object sender, EventArgs e)
     {
 //      if (Report.GetColumnValue(&quot;procEventoNFe.evento.infEvento.tpEvento&quot;).ToString() == &quot;110111&quot;)
-//        
-//      TITULO_CONTEXTO := 'JUSTIFICATIVA';  
-//      TEXTO_EVENTO := &lt;Eventos.&quot;xJust&quot;&gt;;  
-//      end            
+//
+//      TITULO_CONTEXTO := 'JUSTIFICATIVA';
+//      TEXTO_EVENTO := &lt;Eventos.&quot;xJust&quot;&gt;;
+//      end
 //      else
-//      begin              
+//      begin
 //      TITULO_CONTEXTO := 'CORREÇÃO';
-//      TEXTO_EVENTO := &lt;Eventos.&quot;xCorrecao&quot;&gt;;    
+//      TEXTO_EVENTO := &lt;Eventos.&quot;xCorrecao&quot;&gt;;
 //      end;
     }
   }
@@ -475,7 +475,7 @@ namespace FastReport
               <Column Name="vCOFINS" DataType="System.Decimal"/>
               <Column Name="vOutro" DataType="System.Decimal"/>
               <Column Name="vNF" DataType="System.Decimal"/>
-              <Column Name="vTotTrib" DataType="System.Decimal"/>
+              <Column Name="vTotTrib" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vFCP" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vFCPSpecified" DataType="System.Boolean" BindableControl="CheckBox"/>
               <Column Name="vFCPST" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>

--- a/NFe.Danfe.Base/NFe/NFeRetrato.frx
+++ b/NFe.Danfe.Base/NFe/NFeRetrato.frx
@@ -29,16 +29,16 @@ using NFe.Danfe.Base.NFe;
 using NFe.Classes.Informacoes.Total;
 
 namespace FastReport
-{        
+{
   public class ReportScript
-  {    
+  {
     private void Emitente_BeforePrint(object sender, EventArgs e)
     {
       var chave = Substring(((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.Id&quot;)), 3);
-      TextChaveAcesso.Text = Regex.Replace(chave, &quot;.{4}&quot;, &quot;$0 &quot;); 
+      TextChaveAcesso.Text = Regex.Replace(chave, &quot;.{4}&quot;, &quot;$0 &quot;);
       BarcodeChave.Text = chave;
       poEmitLogo.Image = ObterLogo();
-      
+
       var contigenciaId = (string)Report.GetParameterValue(&quot;ContingenciaID&quot;);
       BarCodeContigencia.Visible = !string.IsNullOrEmpty(contigenciaId);
       if(BarCodeContigencia.Visible) BarCodeContigencia.Text = contigenciaId;
@@ -46,11 +46,11 @@ namespace FastReport
       DadosRetencoes.Visible = (bool)Report.GetParameterValue(&quot;ExibeRetencoes&quot;);
       prodRow.AutoSize = (bool)Report.GetParameterValue(&quot;DuasLinhas&quot;);
       if(prodRow.AutoSize == false) prodNomeCell.WordWrap = false;
-      
+
       if (Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.enderEmit.fone&quot;) != null) {
         Text209.Text = FormatarCampo(Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.enderEmit.fone&quot;).ToString(), 'f');
       }
-	  
+
       if ((FinalidadeNFe)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.finNFe&quot;)) == FinalidadeNFe.fnDevolucao)
       {
         var ipi = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ICMSTot.vIPI&quot;)) ?? 0M;
@@ -60,8 +60,8 @@ namespace FastReport
           Text163.Text = FormatNumber(ipiDevolvido,2);
         }
       }
-      
-      //Trato o campo de Frete 
+
+      //Trato o campo de Frete
       switch((int)((ModalidadeFrete)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.modFrete&quot;)))
       {
         case 0: Memo92.Text = &quot;0 - Emit/Remet&quot;; break;
@@ -70,28 +70,28 @@ namespace FastReport
         case 3: Memo92.Text = &quot;3 - Prop Remetente&quot;; break;
         case 4: Memo92.Text = &quot;4 - Prop Destinatário&quot;; break;
         case 9: Memo92.Text = &quot;9 - Sem Frete&quot;; break;
-      } 
-      
+      }
+
       var vol = Report.GetDataSource(&quot;NFe.NFe.infNFe.transp.vol&quot;);
       vol.Init();
-      int qtdeVol = 0; 
-       
+      int qtdeVol = 0;
+
       int volumes = 0;
       decimal pesoL = 0;
       decimal pesoB = 0;
       while (vol.HasMoreRows)
-      {      
+      {
         Memo106.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.esp&quot;));
         Memo108.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.marca&quot;));
         Memo110.Text = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.nVol&quot;));
-                                                                                              
+
         volumes += ((Nullable&lt;int&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.qVol&quot;)) ?? 0;
         pesoL += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoL&quot;)) ?? 0M;
-        pesoB += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoB&quot;)) ?? 0M;   
-        qtdeVol++; 
+        pesoB += ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.transp.vol.pesoB&quot;)) ?? 0M;
+        qtdeVol++;
         vol.Next();
       }
-           
+
       if (qtdeVol &gt;= 1)
       {
         if (qtdeVol &gt; 1)
@@ -100,20 +100,20 @@ namespace FastReport
           Memo108.Text = &quot;&quot;;
           Memo110.Text = &quot;&quot;;
         }
-        
+
         Memo104.Text = volumes.ToString();
         Memo112.Text = FormatNumber(pesoB,3) + &quot; KG&quot;;
         Memo114.Text = FormatNumber(pesoL,3) + &quot; KG&quot;;
-      }  
-           
+      }
+
       if(Engine.FinalPass)
-      { 
+      {
         var vBC = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vBC&quot;)) ?? 0;
         var vISS = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vISS&quot;)) ?? 0;
         var vServ = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.total.ISSQNtot.vServ&quot;)) ?? 0;
-             
+
         DadosISSQN.Visible = !(vBC == 0 &amp;&amp; vISS == 0 &amp;&amp; vServ == 0);
-        
+
         var retiradaCPF = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.CPF&quot;);
         var retiradaCNPJ = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.CNPJ&quot;);
         var retiradaEndereco = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xLgr&quot;);
@@ -121,12 +121,12 @@ namespace FastReport
         var retiradaBairro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xBairro&quot;);
         var retiradaMunicipio = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.xMun&quot;);
         var retiradaUf = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.retirada.UF&quot;);
-        
+
         LocalRetirada.Visible = !string.IsNullOrEmpty(retiradaCPF) || !string.IsNullOrEmpty(retiradaCNPJ) ||
           !string.IsNullOrEmpty(retiradaEndereco) || !string.IsNullOrEmpty(retiradaNro) ||
           !string.IsNullOrEmpty(retiradaBairro) || !string.IsNullOrEmpty(retiradaMunicipio) ||
           !string.IsNullOrEmpty(retiradaUf);
-        
+
         var entregaCPF = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.CPF&quot;);
         var entregaCNPJ = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.CNPJ&quot;);
         var entregaEndereco = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xLgr&quot;);
@@ -134,34 +134,34 @@ namespace FastReport
         var entregaBairro = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xBairro&quot;);
         var entregaMunicipio = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.xMun&quot;);
         var entregaUf = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.entrega.UF&quot;);
-        
+
         LocalEntrega.Visible = !string.IsNullOrEmpty(entregaCPF) || !string.IsNullOrEmpty(entregaCNPJ) ||
           !string.IsNullOrEmpty(entregaEndereco) || !string.IsNullOrEmpty(entregaNro) ||
           !string.IsNullOrEmpty(entregaBairro) || !string.IsNullOrEmpty(entregaMunicipio) ||
           !string.IsNullOrEmpty(entregaUf);
-        
-        
+
+
         var indPagto =   (IndicadorPagamento?)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.indPag&quot;);
-        var fatnFat = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.nFat&quot;); 
+        var fatnFat = (string)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.nFat&quot;);
         var fatvOrig = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vOrig&quot;)) ?? 0M;
         var fatvDesc = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vDesc&quot;)) ?? 0M;
         var fatvLiq = ((Nullable&lt;decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.cobr.fat.vLiq&quot;)) ?? 0M;
-        
-        Fatura.Visible = (bool)Report.GetParameterValue(&quot;ExibeCampoFatura&quot;);   
+
+        Fatura.Visible = (bool)Report.GetParameterValue(&quot;ExibeCampoFatura&quot;);
         MemoFatura.Visible  = !string.IsNullOrEmpty(fatnFat);
         if(MemoFatura.Visible) MemoFatura.Text = string.Format(&quot;Número: {0} - Valor Original: {1:c} - Valor Desconto: {2:c} - ValorLíquido: {3:c}&quot;,
             fatnFat, fatvOrig, fatvDesc, fatvLiq);
-        
+
         switch(indPagto)
         {
           case IndicadorPagamento.ipVista:
             Memo146.Text = &quot;PAGAMENTO À VISTA&quot;;
             break;
-          
+
           case IndicadorPagamento.ipPrazo:
             Memo146.Text = &quot;PAGAMENTO A PRAZO&quot;;
             break;
-          
+
           case IndicadorPagamento.ipOutras:
             Memo146.Text = &quot;OUTROS&quot;;
             break;
@@ -227,35 +227,35 @@ namespace FastReport
 	    prodIPICell.Text = &quot;0,00&quot;;
         prodAlqIPICell.Text = &quot;0,00&quot;;
       }
-      
+
       var imprimirUnidQtdeValor = (ImprimirUnidQtdeValor)Report.GetParameterValue(&quot;ImprimirUnidQtdeValor&quot;);
-      var imprimirDescPorc = (bool)Report.GetParameterValue(&quot;ImprimirDescPorc&quot;);              
+      var imprimirDescPorc = (bool)Report.GetParameterValue(&quot;ImprimirDescPorc&quot;);
       var imprimirTotalLiquido = (bool)Report.GetParameterValue(&quot;ImprimirTotalLiquido&quot;);
-      
+
       var uCom = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.uCom&quot;));
       var uTrib = ((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.uTrib&quot;));
-      
+
       var qCom = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.qCom&quot;));
       var qTrib = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.qTrib&quot;));
-      
+
       var vUnCom = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vUnCom&quot;));
       var vUnTrib = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vUnTrib&quot;));
-      
+
       var vProd = ((Decimal)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vProd&quot;));
       var vDesc = (((Nullable&lt;Decimal&gt;)Report.GetColumnValue(&quot;NFe.NFe.infNFe.det.prod.vDesc&quot;)) ?? 0);
-      
-      if(imprimirTotalLiquido) vProd = vProd - vDesc;      
+
+      if(imprimirTotalLiquido) vProd = vProd - vDesc;
       if(vDesc &gt; 0 &amp;&amp; imprimirDescPorc)
       {
         vDesc = ((vDesc*100)/(vUnCom*qCom));
-      }    
-      
+      }
+
       prodValorCell.Text = FormatNumber(vProd,2);
       prodDescontoCell.Text = FormatNumber(vDesc, 2);
-      
+
       var decimaisQuantidadeItem = (int)Report.GetParameterValue(&quot;DecimaisQuantidadeItem&quot;);
       var decimaisValorUnitario = (int)Report.GetParameterValue(&quot;DecimaisValorUnitario&quot;);
-      
+
       switch(imprimirUnidQtdeValor)
       {
         case ImprimirUnidQtdeValor.Comercial:
@@ -263,26 +263,26 @@ namespace FastReport
           prodQtdCell.Text = FormatNumber(qCom, decimaisQuantidadeItem);
           prodValorUnitarioCell.Text = FormatNumber(vUnCom, decimaisValorUnitario);
           break;
-        
+
         case ImprimirUnidQtdeValor.Tributavel:
           prodUnidadeCell.Text = uTrib;
           prodQtdCell.Text = FormatNumber(qTrib, decimaisQuantidadeItem);
           prodValorUnitarioCell.Text = FormatNumber(vUnTrib, decimaisValorUnitario);
           break;
-        
+
         case ImprimirUnidQtdeValor.Ambos:
-          
+
           var qTribFormatado = FormatNumber(qTrib, decimaisQuantidadeItem);
           var qComFormatado = FormatNumber(qCom, decimaisQuantidadeItem);
           var vUnComFormatado = FormatNumber(vUnCom, decimaisValorUnitario);
           var vUnTribFormatado = FormatNumber(vUnTrib, decimaisValorUnitario);
-          
+
           prodUnidadeCell.Text = string.Format(&quot;{0}{2}{1}&quot;, uCom, uTrib, Environment.NewLine);
           prodQtdCell.Text = string.Format(&quot;{0}{2}{1}&quot;, qComFormatado, qTribFormatado, Environment.NewLine);
           prodValorUnitarioCell.Text = string.Format(&quot;{0}{2}{1}&quot;, vUnComFormatado, vUnTribFormatado, Environment.NewLine);
           break;
       }
-	  
+
       if ((FinalidadeNFe)(Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.finNFe&quot;)) == FinalidadeNFe.fnDevolucao)
       {
         if(ipiBasico == null)
@@ -295,242 +295,242 @@ namespace FastReport
             prodAlqIPICell.Text = FormatNumber(DevolvidoPercentual,2);
 	  }
         }
-      }	  
+      }
     }
-        
+
     private string FormatarCampo(string valor, char format)
     {
       if (valor == null) return string.Empty;
-      
+
       switch (format)
       {
         case 'c':  //CEP
           if (valor.Length == 8)
-            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);          
+            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);
           break;
-        
-        case 'f':  //Telefone /celular         
+
+        case 'f':  //Telefone /celular
           if (valor.Length == 10)
             valor = &quot;(&quot; +valor.Substring(0,2) + &quot;) &quot; + valor.Substring(2,4) + &quot;-&quot; + valor.Substring(6,4);
           else if (valor.Length == 11)
-            valor = &quot;(&quot; +valor.Substring(0,2) + &quot;) &quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);     
+            valor = &quot;(&quot; +valor.Substring(0,2) + &quot;) &quot; + valor.Substring(2,5) + &quot;-&quot; + valor.Substring(7,4);
           break;
-        
+
         case 'd': //cpf / cnpj
           if (valor.Length == 11)
             valor = valor.Substring(0,3)+&quot;.&quot;+valor.Substring(3,3)+&quot;.&quot;+valor.Substring(6,3)+&quot;-&quot;+valor.Substring(9,2);
           else if (valor.Length == 14)
             valor = valor.Substring(0,2)+&quot;.&quot;+valor.Substring(2,3)+&quot;.&quot;+valor.Substring(5,3)+&quot;/&quot;+valor.Substring(8,4)+&quot;-&quot;+valor.Substring(12,2);
-          break;  
-        
+          break;
+
         case 'p':
           if (valor.Length == 7)
             valor = valor.Substring(0,3)+&quot;-&quot;+valor.Substring(3,4);
           break;
-      }                               
+      }
       return valor;
     }
-    
+
     public Image ObterLogo()
     {
       byte[] logomarca = Report.GetParameterValue(&quot;Logo&quot;) as byte[];
-      
+
       if (logomarca == null) return null;
-      
+
       using(var ms = new MemoryStream(logomarca))
       {
         var image = Image.FromStream(ms);
         return image;
       }
-    }       
+    }
 
     private void Imposto_BeforePrint(object sender, EventArgs e)
     {
       bool exibirIbpt = ((Boolean?)Report.GetParameterValue(&quot;ExibirTotalTributos&quot;)) ?? false;
-      
+
       QuadroVTOTTRIB.Visible = exibirIbpt;
       txtIbptValor.Visible = exibirIbpt;
-      
+
       if (exibirIbpt)
-      { 
+      {
         //Base ICMS
         QuadroVBC.Width = 100f;
         Text170.Width = QuadroVBC.Width;
-        
+
         //Valor ICMS
         QuadroVICMS.Width = 100f;
         QuadroVICMS.Left = 100f;
         Text169.Width = QuadroVICMS.Width;
         Text169.Left = QuadroVICMS.Left;
-        
+
         //Base Calc ICMS ST
         QuadroVBCST.Text = &quot;BASE CÁLC. ICMS SUBST.&quot;;
         QuadroVBCST.Width = 100f;
         QuadroVBCST.Left = 200f;
         Text168.Width = QuadroVBCST.Width;
-        Text168.Left = QuadroVBCST.Left;                   
-        
+        Text168.Left = QuadroVBCST.Left;
+
         //ICMS ST
         QuadrovST.Width = 100f;
         QuadrovST.Left = 300f;
         Text162.Width = QuadrovST.Width;
         Text162.Left = QuadrovST.Left;
-                
+
         //PIS
         QuadroPIS.Width = 100f;
         QuadroPIS.Left = 400f;
         Text160.Width = QuadroPIS.Width;
         Text160.Left = QuadroPIS.Left;
- 
+
         //TOTAL TRIBUTOS
         QuadroVTOTTRIB.Width = 100f;
         QuadroVTOTTRIB.Left = 500f;
         txtIbptValor.Width = QuadroVTOTTRIB.Width;
         txtIbptValor.Left = QuadroVTOTTRIB.Left;
-        
+
         //Total produtos
         Memo67.Left = 600f;
         Memo67.Width = 144.5f;
         Text159.Width = Memo67.Width;
-        Text159.Left = Memo67.Left;              
-        
+        Text159.Left = Memo67.Left;
+
         //Frete
         Memo77.Left = 0f;
         Memo77.Width = 100f;
         Text167.Width = Memo77.Width;
-        Text167.Left = Memo77.Left;  
-        
+        Text167.Left = Memo77.Left;
+
         //Seguro
         Memo75.Left = 100f;
         Memo75.Width = 100f;
         Text166.Width = Memo75.Width;
-        Text166.Left = Memo75.Left; 
-        
+        Text166.Left = Memo75.Left;
+
         //Desconto
         Memo73.Left = 200f;
         Memo73.Width = 100f;
         Text165.Width = Memo73.Width;
-        Text165.Left = Memo73.Left; 
-        
+        Text165.Left = Memo73.Left;
+
         //Despesas
         Memo71.Left = 300f;
         Memo71.Width = 100f;
         Text164.Width = Memo71.Width;
-        Text164.Left = Memo71.Left; 
-        
+        Text164.Left = Memo71.Left;
+
         //IPI
         Memo69.Left = 400f;
         Memo69.Width = 100f;
         Text163.Width = Memo69.Width;
-        Text163.Left = Memo69.Left; 
-        
+        Text163.Left = Memo69.Left;
+
         //Valor Cofins
         Text158.Left = 500f;
         Text158.Width = 100f;
         Text161.Width = Text158.Width;
-        Text161.Left = Text158.Left; 
-        
+        Text161.Left = Text158.Left;
+
         //Total Contábil
         Memo79.Left = 600f;
         Memo79.Width = 144.5f;
         Memo80.Width = Memo79.Width;
         Memo80.Left = Memo79.Left;
-      }     
+      }
     }
-            
-    private int contadorDuplicatas =0;    
+
+    private int contadorDuplicatas =0;
     private float _TamanhoDuplicatas = 0;
 
     private void DuplicatasHeader_BeforePrint(object sender, EventArgs e)
     {
       contadorDuplicatas = 0;
       _TamanhoDuplicatas = 0;
-    }   
-    
+    }
+
     private void Duplicatas_BeforePrint(object sender, EventArgs e)
     {
       contadorDuplicatas++;
       if (contadorDuplicatas == 6)
-      {       
+      {
         _TamanhoDuplicatas += Duplicatas.Height;
         contadorDuplicatas = 0;
       }
     }
-  
+
     private float _Tamanho = 0;
     private float _TamanhoItens = 0;
-    
+
     private void DadosProdutosHeader_BeforePrint(object sender, EventArgs e)
     {
-      
+
       if (((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacional || ((CRT)Report.GetColumnValue(&quot;NFe.NFe.infNFe.emit.CRT&quot;)) == CRT.SimplesNacionalMei) {
 	    Memo119.Text = &quot;O/CSOSN&quot;;
       }
-      
+
       _Tamanho = 0;
-      _TamanhoItens = 0;  
-      
+      _TamanhoItens = 0;
+
       if (Canhoto.Visible)
         _Tamanho += Canhoto.Height;
-      
+
       if (Emitente.Visible)
         _Tamanho += Emitente.Height;
-      
+
       if (Destinatario.Visible)
         _Tamanho += Destinatario.Height;
-      
+
       if (LocalRetirada.Visible)
         _Tamanho += LocalRetirada.Height;
-      
+
       if (LocalEntrega.Visible)
         _Tamanho += LocalEntrega.Height;
-      
+
       if (Fatura.Visible)
         _Tamanho += Fatura.Height;
-      
+
       if (DuplicatasHeader.Visible)
         _Tamanho += DuplicatasHeader.Height;
-      
+
       _Tamanho += _TamanhoDuplicatas;
-      
+
       if (Imposto.Visible)
         _Tamanho += Imposto.Height;
-      
+
       if (TransportadorVolumes.Visible)
         _Tamanho += TransportadorVolumes.Height;
-      
+
       if (DadosProdutosHeader.Visible)
         _Tamanho += DadosProdutosHeader.Height;
-      
+
       //_Tamanho += _TamanhoItens;
-      
+
       if (DadosProdutosFooter.Visible)
         _Tamanho += DadosProdutosFooter.Height;
-      
+
       if (DadosISSQN.Visible)
         _Tamanho += DadosISSQN.Height;
-      
+
       if (DadosRetencoes.Visible)
         _Tamanho += DadosRetencoes.Height;
-      
+
       DadosAdicionais.CalcHeight();
-      
+
       if (DadosAdicionais.Visible)
         _Tamanho += DadosAdicionais.Height;
-      
+
       if (Rodape.Visible)
-        _Tamanho += Rodape.Height;     
-          
+        _Tamanho += Rodape.Height;
+
     }
-    
+
     private void DadosProdutos_AfterPrint(object sender, EventArgs e)
-    {           
+    {
       DadosProdutos.StartNewPage = false;
-      
+
       if (Engine.PageNo == 1)
       {
         _TamanhoItens += DadosProdutos.Height;
-        
+
         if (_Tamanho + _TamanhoItens &gt;= Engine.PageHeight)
         {
           DadosProdutos.StartNewPage = true;
@@ -538,9 +538,9 @@ namespace FastReport
         }
       }
     }
-    
 
-    
+
+
   }
 }     </ScriptText>
   <Dictionary>
@@ -913,7 +913,7 @@ namespace FastReport
               <Column Name="vCOFINS" DataType="System.Decimal"/>
               <Column Name="vOutro" DataType="System.Decimal"/>
               <Column Name="vNF" DataType="System.Decimal"/>
-              <Column Name="vTotTrib" DataType="System.Decimal"/>
+              <Column Name="vTotTrib" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vFCPUFDest" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vICMSUFDest" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
               <Column Name="vICMSUFRemet" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>

--- a/NFe.Danfe.Base/NFe/NFeSimplificado.frx
+++ b/NFe.Danfe.Base/NFe/NFeSimplificado.frx
@@ -38,10 +38,10 @@ namespace FastReport
       {
         case 'c':  //CEP
           if (valor.Length == 8)
-            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);          
+            valor = valor.Substring(0,2) + &quot;.&quot; + valor.Substring(2,3) + &quot;-&quot; + valor.Substring(5,3);
           break;
-	
-        case 'f':  //Telefone /celular         
+
+        case 'f':  //Telefone /celular
           if (valor.Length == 10)
             valor = &quot;(&quot; +valor.Substring(0,2) + &quot;)&quot; + valor.Substring(2,4) + &quot;-&quot; + valor.Substring(6,4);
           else if (valor.Length == 11)
@@ -51,63 +51,63 @@ namespace FastReport
           else if (valor.Length == 11) //55+11
             valor = &quot;(&quot; +valor.Substring(2,2) + &quot;)&quot; + valor.Substring(4,5) + &quot;-&quot; + valor.Substring(9,4);
           break;
-	
+
         case 'd': //cpf / cnpj
           if (valor.Length == 11)
             valor = valor.Substring(0,3)+&quot;.&quot;+valor.Substring(3,3)+&quot;.&quot;+valor.Substring(6,3)+&quot;-&quot;+valor.Substring(9,2);
           else if (valor.Length == 14)
             valor = valor.Substring(0,2)+&quot;.&quot;+valor.Substring(2,3)+&quot;.&quot;+valor.Substring(5,3)+&quot;/&quot;+valor.Substring(8,4)+&quot;-&quot;+valor.Substring(12,2);
-          break;  
-	
+          break;
+
         case 'p':
           if (valor.Length == 7)
             valor = valor.Substring(0,3)+&quot;-&quot;+valor.Substring(3,4);
           break;
-      }      
-      
-      
+      }
+
+
       return valor;
     }
-    
+
     private void Data1_BeforePrint(object sender, EventArgs e)
     {
       TheLogotipo.Image = ObterLogo();
-      
+
       var chave = (((String)Report.GetColumnValue(&quot;NFe.NFe.infNFe.Id&quot;))).Substring(3);
-      Text1.Text = Regex.Replace(chave, &quot;.{4}&quot;, &quot;$0 &quot;); 
-      
+      Text1.Text = Regex.Replace(chave, &quot;.{4}&quot;, &quot;$0 &quot;);
+
       Text38.Visible = ((Boolean?)Report.GetParameterValue(&quot;EsconderValor&quot;)) != true;
       Text36.Visible = ((Boolean?)Report.GetParameterValue(&quot;EsconderValor&quot;)) != true;
-      
+
       var emissao = ((TipoEmissao)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.tpEmis&quot;));
       switch (emissao)
       {
-        case TipoEmissao.teNormal: Text33.Text = &quot;Tipo: Normal&quot;; break;        
+        case TipoEmissao.teNormal: Text33.Text = &quot;Tipo: Normal&quot;; break;
         case TipoEmissao.teEPEC: Text33.Text = &quot;Tipo: EPEC&quot;; break;
         case TipoEmissao.teFSDA: Text33.Text = &quot;Tipo: FS-DA&quot;; break;
-        case TipoEmissao.teFSIA: Text33.Text = &quot;Tipo: FS-IA&quot;; break;        
+        case TipoEmissao.teFSIA: Text33.Text = &quot;Tipo: FS-IA&quot;; break;
         case TipoEmissao.teSCAN: Text33.Text = &quot;Tipo: SCAN&quot;; break;
         case TipoEmissao.teSVCAN: Text33.Text = &quot;Tipo: SVC-AN&quot;; break;
-        case TipoEmissao.teSVCRS: Text33.Text = &quot;Tipo: SVC-RS&quot;; break;       
-        case TipoEmissao.teOffLine: Text33.Text = &quot;Tipo: Offline&quot;; break;        
-        default: throw new ArgumentException(&quot;tpEmis não implementado&quot;); 
-      }     
-      
-      var operacao = ((TipoNFe)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.tpNF&quot;));      
+        case TipoEmissao.teSVCRS: Text33.Text = &quot;Tipo: SVC-RS&quot;; break;
+        case TipoEmissao.teOffLine: Text33.Text = &quot;Tipo: Offline&quot;; break;
+        default: throw new ArgumentException(&quot;tpEmis não implementado&quot;);
+      }
+
+      var operacao = ((TipoNFe)Report.GetColumnValue(&quot;NFe.NFe.infNFe.ide.tpNF&quot;));
       switch (operacao)
       {
         case TipoNFe.tnEntrada : Text37.Text = &quot;Operação: Entrada&quot;; break;
         case TipoNFe.tnSaida : Text37.Text = &quot;Operação: Saída&quot;; break;
         default: throw new ArgumentException(&quot;tpNF não implementado&quot;);
-      }           
+      }
     }
-    
+
     public Image ObterLogo()
     {
       byte[] logomarca = Report.GetParameterValue(&quot;Logo&quot;) as byte[];
-      
+
       if (logomarca == null) return null;
-      
+
       using(var ms = new MemoryStream(logomarca))
       {
         var image = Image.FromStream(ms);
@@ -290,7 +290,7 @@ namespace FastReport
               <Column Name="vCOFINS" DataType="System.Decimal"/>
               <Column Name="vOutro" DataType="System.Decimal"/>
               <Column Name="vNF" DataType="System.Decimal"/>
-              <Column Name="vTotTrib" DataType="System.Decimal"/>
+              <Column Name="vTotTrib" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>
             </Column>
             <Column Name="ISSQNtot" DataType="NFe.Classes.Informacoes.Total.ISSQNtot, NFe.Classes, Version=1.0.0.772, Culture=neutral, PublicKeyToken=null">
               <Column Name="vServ" DataType="System.Nullable`1[[System.Decimal, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]]"/>

--- a/NFe.Danfe.Nativo/NFCe/DanfeNativoNfce.cs
+++ b/NFe.Danfe.Nativo/NFCe/DanfeNativoNfce.cs
@@ -119,7 +119,7 @@ namespace NFe.Danfe.Nativo.NFCe
                 }
 
                 // Obtive o tamanho real na posição y agora vou fazer um com tamanho exato
-                using (Bitmap bmpFinal = new Bitmap(300, _y))   
+                using (Bitmap bmpFinal = new Bitmap(300, _y))
                 using (var streamer = new MemoryStream())
                 {
                     using (Graphics g = Graphics.FromImage(bmpFinal))
@@ -559,7 +559,7 @@ namespace NFe.Danfe.Nativo.NFCe
 
             _y += 5;
 
-            var tributosIncidentes = _nfe.infNFe.total.ICMSTot.vTotTrib;
+            var tributosIncidentes = _nfe.infNFe.total.ICMSTot.vTotTrib ?? 0;
 
             if (tributosIncidentes != 0)
             {


### PR DESCRIPTION
No manual da NFe/NFCe o campo vTotTrib (W16a) é opcional. A alteração torna o campo nullable para gerar a tag no xml somente quando houver valor. Também foi ajustado o tipo do campo nos projetos Danfe.Base e Danfe.Nativo.

Resolve #85 