### PR TITLE
Remoção validação que impede o uso do certificado A1ByteArray para gerar QRCode v3

### DIFF
--- a/NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
+++ b/NFe.Utils/InformacoesSuplementares/ExtinfNFeSupl.cs
@@ -444,10 +444,10 @@ namespace NFe.Utils.InformacoesSuplementares
 
             const string pipe = "|";
 
-            //Chave de Acesso da NFC-e 
+            //Chave de Acesso da NFC-e
             var chave = nfe.infNFe.Id.Substring(3);
 
-            //Identificação do Ambiente (1 – Produção, 2 – Homologação) 
+            //Identificação do Ambiente (1 – Produção, 2 – Homologação)
             var ambiente = (int)nfe.infNFe.ide.tpAmb;
 
             //Identificador do CSC (Código de Segurança do Contribuinte no Banco de Dados da SEFAZ). Informar sem os zeros não significativos
@@ -498,8 +498,8 @@ namespace NFe.Utils.InformacoesSuplementares
         /// </summary>
         public static string ObterUrlQrCode3(this infNFeSupl infNFeSupl, Classes.NFe nfe, VersaoServico versaoServico, ConfiguracaoCertificado cfgCertificado, Encoding encoding = null)
         {
-            if (cfgCertificado == null || (string.IsNullOrWhiteSpace(cfgCertificado.Serial) && cfgCertificado.TipoCertificado != TipoCertificado.A1Arquivo))
-                throw new ArgumentNullException("CertificadoDigital", "Para gerar a assinatura do QR-Code versão 3.0 EM CONTINGENCIA é necessário informar o certificado digital utilizado na assinatura da NFC-e, verificar Número de Série e Senha.");
+            if (cfgCertificado == null)
+                throw new ArgumentNullException(nameof(cfgCertificado), "Para gerar a assinatura do QR-Code versão 3.0 EM CONTINGENCIA é necessário informar o certificado digital utilizado na assinatura da NFC-e");
 
             const string pipe = "|";
 


### PR DESCRIPTION
Quando utilizando certificado A1 como array de bytes não é possível gerar QRCode v3 devido uma validação no método que gerar o QRCode.
A validação testa se o serial do certificado foi informado. Mas isso só necessário para A1Repositorio e A3. Como a validação já é realizado no método de carregar certificado não é necessário validar no método que gera o QRCode v3.