### PR TITLE
NT2024.003v1.03: Grupo defensivos em agropecuario passou permitir multiplas ocorrências

### DIFF
--- a/NFe.Classes/Informacoes/Agropecuario/agropecuario.cs
+++ b/NFe.Classes/Informacoes/Agropecuario/agropecuario.cs
@@ -1,36 +1,39 @@
-﻿namespace NFe.Classes.Informacoes.Agropecuario
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Agropecuario
 {
     public class agropecuario
     {
 #if NET5_0_OR_GREATER//o uso de tipos de referência anuláveis não é permitido até o C# 8.0.
 
         /// <summary>
-        /// ZF02 - serieGuia
+        /// ZF02 - Defensivos Agrícolas
         /// </summary>
-        public defensivo? defensivo { get; set; }
+        [XmlElement("defensivo")]
+        public List<defensivo>? defensivo { get; set; }
 
         /// <summary>
         /// ZF04 - Guia de Trânsito
         /// </summary>
+        [XmlElement("guiaTransito")]
         public guiaTransito? guiaTransito { get; set; }
 
-        public bool ShouldSerializedefensivo()
-        {
-            return defensivo != null;
-        }
         public bool ShouldSerializeguiaTransito()
         {
             return guiaTransito != null;
         }
 #else
         /// <summary>
-        /// ZF02 - serieGuia
+        /// ZF02 - Defensivos Agrícolas
         /// </summary>
-        public defensivo defensivo { get; set; }
+        [XmlElement("defensivo")]
+        public List<defensivo> defensivo { get; set; }
 
         /// <summary>
         /// ZF04 - Guia de Trânsito
         /// </summary>
+        [XmlElement("guiaTransito")]
         public guiaTransito guiaTransito { get; set; }
 #endif
     }


### PR DESCRIPTION
O grupo agropecuario permite multiplas ocorrências do grupo defensivos a partir da NT2024.003v1.03.
Foi alterado a propriedade defensivos, da classe agropecuario, para uma lista para permitir informa a lista de objetos.