### PR TITLE
MDFe - NT 2025.001

### DIFF
--- a/MDFe.Classes/Informacoes/tpCarga.cs
+++ b/MDFe.Classes/Informacoes/tpCarga.cs
@@ -36,5 +36,8 @@ namespace MDFe.Classes.Informacoes
 
         [XmlEnum("11")]
         PerigosaCargaGeral = 11,
+
+        [XmlEnum("12")]
+        GranelPressurizada = 12,
     }
 }

--- a/MDFe.Classes/Informacoes/tpComp.cs
+++ b/MDFe.Classes/Informacoes/tpComp.cs
@@ -13,6 +13,9 @@ namespace MDFe.Classes.Informacoes
         [XmlEnum("03")]
         DespesasBancariasEmiosDePagamentoOutras = 03,
 
+        [XmlEnum("04")]
+        Frete = 04,
+
         [XmlEnum("99")]
         Outros = 99
     }

--- a/MDFe.Classes/Informacoes/tpValePed.cs
+++ b/MDFe.Classes/Informacoes/tpValePed.cs
@@ -11,6 +11,9 @@ namespace MDFe.Classes.Informacoes
         Cupom = 02,
 
         [XmlEnum("03")]
-        Cartao = 03
+        Cartao = 03,
+
+        [XmlEnum("04")]
+        LeituraDePlaca = 04,
     }
 }


### PR DESCRIPTION
MDFe: Ajustes para NT 2025.001 v1.02

- tpCarga: Adicionada opção Granel Pressurizada.
- tpComp: Adicionada opção Frete.
- tpValePed: Adicionada opção Leitura de Placa.

Obs: Não ajustei o `Campo MMSI no modal Aquaviário` pois utilizamos apenas modal rodoviário e não consigo testar no momento.

Link dos documentos: https://dfe-portal.svrs.rs.gov.br/Mdfe/Documentos
Possui atualização de schemas.