### PR TITLE
Forçando ordenação dos campos no XML nos novos campos da reforma tributaria

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/IBSCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/IBSCBS.cs
@@ -1,23 +1,31 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class IBSCBS
     {
         // UB13
+        [XmlElement(Order = 1)]
         public CSTIBSCBS CST { get; set; }
 
         // UB14
+        [XmlElement(Order = 2)]
         public cClassTrib cClassTrib { get; set; }
 
         // UB15
+        [XmlElement(Order = 3)]
         public gIBSCBS gIBSCBS { get; set; }
 
         // UB84
+        [XmlElement(Order = 4)]
         public gIBSCBSMono gIBSCBSMono { get; set; }
 
         // UB106
+        [XmlElement(Order = 5)]
         public gTransfCred gTransfCred { get; set; }
 
         // UB109
+        [XmlElement(Order = 6)]
         public gCredPresIBSZFM gCredPresIBSZFM { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/IS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/IS.cs
@@ -11,12 +11,15 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
         private decimal _vIs;
 
         // UB02
+        [XmlElement(Order = 1)]
         public CSTIS CSTIS { get; set; }
 
         // UB03
+        [XmlElement(Order = 2)]
         public cClassTribIS cClassTribIS { get; set; }
 
         // UB05
+        [XmlElement(Order = 3)]
         public decimal vBCIS
         {
             get => _vBcIs.Arredondar(2);
@@ -24,6 +27,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
         }
 
         // UB06
+        [XmlElement(Order = 4)]
         public decimal pIS
         {
             get => _pIs.Arredondar(4);
@@ -31,6 +35,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
         }
 
         // UB07
+        [XmlElement(Order = 5)]
         public decimal? pISEspec
         {
             get => _pIsEspec.Arredondar(4);
@@ -42,9 +47,11 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
         }
 
         // UB09
+        [XmlElement(Order = 6)]
         public string uTrib { get; set; }
 
         // UB10
+        [XmlElement(Order = 7)]
         public decimal qTrib
         {
             get => _qTrib.Arredondar(4);
@@ -52,6 +59,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao
         }
 
         // UB11
+        [XmlElement(Order = 8)]
         public decimal vIS
         {
             get => _vIs.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gCBS.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gCBS
     {
@@ -6,6 +8,7 @@
         private decimal _vGBS;
 
         // UB37
+        [XmlElement(Order = 1)]
         public decimal pCBS
         {
             get => _pGBS.Arredondar(4);
@@ -13,15 +16,19 @@
         }
 
         // UB40
+        [XmlElement(Order = 2)]
         public gDif gDif { get; set; }
 
         // UB43
+        [XmlElement(Order = 3)]
         public gDevTrib gDevTrib { get; set; }
 
         // UB45
+        [XmlElement(Order = 4)]
         public gRed gRed { get; set; }
 
         // UB67
+        [XmlElement(Order = 5)]
         public decimal vCBS
         {
             get => _vGBS.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gCredPresIBSZFM.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gCredPresIBSZFM.cs
@@ -1,13 +1,17 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gCredPresIBSZFM
     {
         private decimal? _vCredPresIbsZfm;
 
         // UB110
+        [XmlElement(Order = 1)]
         public tpCredPresIBSZFM tpCredPresIBSZFM { get; set; }
 
         // UB111
+        [XmlElement(Order = 2)]
         public decimal? vCredPresIBSZFM
         {
             get => _vCredPresIbsZfm.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSCBS.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSCBS.cs
@@ -1,10 +1,13 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gIBSCBS
     {
         private decimal _vBc;
 
         // UB16
+        [XmlElement(Order = 1)]
         public decimal vBC
         {
             get => _vBc.Arredondar(2);
@@ -12,24 +15,31 @@
         }
 
         // UB17
+        [XmlElement(Order = 2)]
         public gIBSUF gIBSUF { get; set; }
 
         // UB36
+        [XmlElement(Order = 3)]
         public gIBSMun gIBSMun { get; set; }
 
         // UB55
+        [XmlElement(Order = 4)]
         public gCBS gCBS { get; set; }
 
         // UB68
+        [XmlElement(Order = 5)]
         public gTribRegular gTribRegular { get; set; }
 
         // UB73
+        [XmlElement(Order = 6)]
         public gIBSCredPres gIBSCredPres { get; set; }
 
         // UB78
+        [XmlElement(Order = 7)]
         public gIBSCredPres gCBSCredPres { get; set; }
 
         // UB82a
+        [XmlElement(Order = 8)]
         public gTribCompraGov gTribCompraGov { get; set; }
     }
 }

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSCBSMono.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSCBSMono.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gIBSCBSMono
     {
@@ -6,18 +8,23 @@
         private decimal _vTotCbsMonoItem;
 
         // UB84a
+        [XmlElement(Order = 1)]
         public gMonoPadrao gMonoPadrao { get; set; }
 
         // UB90
+        [XmlElement(Order = 2)]
         public gMonoReten gMonoReten { get; set; }
 
         // UB94
+        [XmlElement(Order = 3)]
         public gMonoRet gMonoRet { get; set; }
 
         // UB99
+        [XmlElement(Order = 4)]
         public gMonoDif gMonoDif { get; set; }
 
         // UB104
+        [XmlElement(Order = 5)]
         public decimal vTotIBSMonoItem
         {
             get => _vTotIbsMonoItem.Arredondar(2);
@@ -25,6 +32,7 @@
         }
 
         // UB105
+        [XmlElement(Order = 6)]
         public decimal vTotCBSMonoItem
         {
             get => _vTotCbsMonoItem.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSCredPres.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSCredPres.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gIBSCredPres
     {
@@ -7,9 +9,11 @@
         private decimal _vCredPresCondSus;
 
         // UB74
+        [XmlElement(Order = 1)]
         public TipocCredPres cCredPres { get; set; }
 
         // UB75
+        [XmlElement(Order = 2)]
         public decimal pCredPres
         {
             get => _pCredPres.Arredondar(4);
@@ -17,6 +21,7 @@
         }
 
         // UB76
+        [XmlElement(Order = 3)]
         public decimal vCredPres
         {
             get => _vCredPres.Arredondar(2);
@@ -24,6 +29,7 @@
         }
 
         // UB77
+        [XmlElement(Order = 4)]
         public decimal vCredPresCondSus
         {
             get => _vCredPresCondSus.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSMun.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSMun.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gIBSMun
     {
@@ -6,6 +8,7 @@
         private decimal _vIbsMun;
 
         // UB37
+        [XmlElement(Order = 1)]
         public decimal pIBSMun
         {
             get => _pIbsMun.Arredondar(4);
@@ -13,15 +16,19 @@
         }
 
         // UB40
+        [XmlElement(Order = 2)]
         public gDif gDif { get; set; }
 
         // UB43
+        [XmlElement(Order = 3)]
         public gDevTrib gDevTrib { get; set; }
 
         // UB45
+        [XmlElement(Order = 4)]
         public gRed gRed { get; set; }
 
         // UB54
+        [XmlElement(Order = 5)]
         public decimal vIBSMun
         {
             get => _vIbsMun.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSUF.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gIBSUF.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gIBSUF
     {
@@ -6,6 +8,7 @@
         private decimal _vIbsUf;
 
         // UB18
+        [XmlElement(Order = 1)]
         public decimal pIBSUF
         {
             get => _pIbsUf.Arredondar(4);
@@ -13,15 +16,19 @@
         }
 
         // UB21
+        [XmlElement(Order = 2)]
         public gDif gDif { get; set; }
 
         // UB24
+        [XmlElement(Order = 3)]
         public gDevTrib gDevTrib { get; set; }
 
         // UB26
+        [XmlElement(Order = 4)]
         public gRed gRed { get; set; }
 
         // UB35
+        [XmlElement(Order = 5)]
         public decimal vIBSUF
         {
             get => _vIbsUf.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoDif.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoDif.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gMonoDif
     {
@@ -8,6 +10,7 @@
         private decimal _vCbsMonoDif;
 
         // UB100
+        [XmlElement(Order = 1)]
         public decimal pDifIBS
         {
             get => _pDifIbs.Arredondar(4);
@@ -15,6 +18,7 @@
         }
 
         // UB101
+        [XmlElement(Order = 2)]
         public decimal vIBSMonoDif
         {
             get => _vIbsMonoDif.Arredondar(2);
@@ -22,6 +26,7 @@
         }
 
         // UB102
+        [XmlElement(Order = 3)]
         public decimal pDifCBS
         {
             get => _pDifCbs.Arredondar(4);
@@ -29,6 +34,7 @@
         }
 
         // UB103
+        [XmlElement(Order = 4)]
         public decimal vCBSMonoDif
         {
             get => _vCbsMonoDif.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoPadrao.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoPadrao.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gMonoPadrao
     {
@@ -9,6 +11,7 @@
         private decimal _vCbsMono;
 
         // UB85
+        [XmlElement(Order = 1)]
         public decimal qBCMono
         {
             get => _qBcMono.Arredondar(4);
@@ -16,6 +19,7 @@
         }
 
         // UB86
+        [XmlElement(Order = 2)]
         public decimal adRemIBS
         {
             get => _adRemIbs.Arredondar(4);
@@ -23,6 +27,7 @@
         }
 
         // UB87
+        [XmlElement(Order = 3)]
         public decimal adRemCBS
         {
             get => _adRemCbs.Arredondar(4);
@@ -30,6 +35,7 @@
         }
 
         // UB88
+        [XmlElement(Order = 4)]
         public decimal vIBSMono
         {
             get => _vIbsMono.Arredondar(2);
@@ -37,6 +43,7 @@
         }
 
         // UB89
+        [XmlElement(Order = 5)]
         public decimal vCBSMono
         {
             get => _vCbsMono.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoRet.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoRet.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gMonoRet
     {
@@ -9,6 +11,7 @@
         private decimal _vCbsMonoRet;
 
         // UB95
+        [XmlElement(Order = 1)]
         public decimal qBCMonoRet
         {
             get => _qBcMonoRet.Arredondar(4);
@@ -16,6 +19,7 @@
         }
 
         // UB96
+        [XmlElement(Order = 2)]
         public decimal adRemIBSRet
         {
             get => _adRemIbsRet.Arredondar(4);
@@ -23,6 +27,7 @@
         }
 
         // UB97
+        [XmlElement(Order = 3)]
         public decimal vIBSMonoRet
         {
             get => _vIbsMonoRet.Arredondar(2);
@@ -30,6 +35,7 @@
         }
 
         // UB98
+        [XmlElement(Order = 4)]
         public decimal adRemCBSRet
         {
             get => _adRemCbsRet.Arredondar(4);
@@ -37,6 +43,7 @@
         }
 
         // UB98a
+        [XmlElement(Order = 5)]
         public decimal vCBSMonoRet
         {
             get => _vCbsMonoRet.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoReten.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gMonoReten.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gMonoReten
     {
@@ -9,6 +11,7 @@
         private decimal _vCbsMonoReten;
 
         // UB91
+        [XmlElement(Order = 1)]
         public decimal qBCMonoReten
         {
             get => _qBcMonoReten.Arredondar(4);
@@ -16,6 +19,7 @@
         }
 
         // UB92
+        [XmlElement(Order = 2)]
         public decimal adRemIBSReten
         {
             get => _adRemIbsReten.Arredondar(4);
@@ -23,6 +27,7 @@
         }
 
         // UB93
+        [XmlElement(Order = 3)]
         public decimal vIBSMonoReten
         {
             get => _vIbsMonoReten.Arredondar(2);
@@ -30,6 +35,7 @@
         }
 
         // UB93a
+        [XmlElement(Order = 4)]
         public decimal adRemCBSReten
         {
             get => _adRemCbsReten.Arredondar(4);
@@ -37,6 +43,7 @@
         }
 
         // UB93b
+        [XmlElement(Order = 5)]
         public decimal vCBSMonoReten
         {
             get => _vCbsMonoReten.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gTransfCred.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gTransfCred.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gTransfCred
     {
@@ -6,6 +8,7 @@
         private decimal _vCbs;
 
         // UB107
+        [XmlElement(Order = 1)]
         public decimal vIBS
         {
             get => _vIbs.Arredondar(2);
@@ -13,6 +16,7 @@
         }
 
         // UB108
+        [XmlElement(Order = 2)]
         public decimal vCBS
         {
             get => _vCbs.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gTribCompraGov.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gTribCompraGov.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gTribCompraGov
     {
@@ -10,6 +12,7 @@
         private decimal _vTribCbs;
 
         // UB82b
+        [XmlElement(Order = 1)]
         public decimal pAliqIBSUF
         {
             get => _pAliqIbsUf.Arredondar(4);
@@ -17,6 +20,7 @@
         }
 
         // UB82c
+        [XmlElement(Order = 2)]
         public decimal vTribIBSUF
         {
             get => _vTribIbsUf.Arredondar(2);
@@ -24,6 +28,7 @@
         }
 
         // UB82d
+        [XmlElement(Order = 3)]
         public decimal pAliqIBSMun
         {
             get => _pAliqIbsMun.Arredondar(4);
@@ -31,6 +36,7 @@
         }
 
         // UB82e
+        [XmlElement(Order = 4)]
         public decimal vTribIBSMun
         {
             get => _vTribIbsMun.Arredondar(2);
@@ -38,6 +44,7 @@
         }
 
         // UB82f
+        [XmlElement(Order = 5)]
         public decimal pAliqCBS
         {
             get => _pAliqCbs.Arredondar(4);
@@ -45,6 +52,7 @@
         }
 
         // UB82g
+        [XmlElement(Order = 6)]
         public decimal vTribCBS
         {
             get => _vTribCbs.Arredondar(2);

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/gTribRegular.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/gTribRegular.cs
@@ -1,4 +1,6 @@
-﻿namespace NFe.Classes.Informacoes.Detalhe.Tributacao
+﻿using System.Xml.Serialization;
+
+namespace NFe.Classes.Informacoes.Detalhe.Tributacao
 {
     public class gTribRegular
     {
@@ -10,12 +12,15 @@
         private decimal _vTribRegCbs;
 
         // UB69
+        [XmlElement(Order = 1)]
         public CSTIBSCBS CSTReg { get; set; }
 
         // UB70
+        [XmlElement(Order = 2)]
         public cClassTrib cClassTribReg { get; set; }
 
         // UB71
+        [XmlElement(Order = 3)]
         public decimal pAliqEfetRegIBSUF
         {
             get => _pAliqEfetRegIbsUf.Arredondar(4);
@@ -23,6 +28,7 @@
         }
 
         // UB72
+        [XmlElement(Order = 4)]
         public decimal vTribRegIBSUF
         {
             get => _vTribRegIbsUf.Arredondar(2);
@@ -30,6 +36,7 @@
         }
 
         // UB72a
+        [XmlElement(Order = 5)]
         public decimal pAliqEfetRegIBSMun
         {
             get => _pAliqEfetRegIbsMun.Arredondar(4);
@@ -37,6 +44,7 @@
         }
 
         // UB72b
+        [XmlElement(Order = 6)]
         public decimal vTribRegIBSMun
         {
             get => _vTribRegIbsMun.Arredondar(2);
@@ -44,6 +52,7 @@
         }
 
         // UB72c
+        [XmlElement(Order = 7)]
         public decimal pAliqEfetRegCBS
         {
             get => _pAliqEfetRegCbs.Arredondar(4);
@@ -51,6 +60,7 @@
         }
 
         // UB72d
+        [XmlElement(Order = 8)]
         public decimal vTribRegCBS
         {
             get => _vTribRegCbs.Arredondar(2);


### PR DESCRIPTION
Simplesmente adicione o XMLElement(Order =X ) em todos as novas classes da reforma (det.imposto) que tinham o comentario sobre o campo no manual.
Não consegui testar se alguem conseguir validar agradeço