### PR TITLE
Adiciona campo PIX ao infBanc do infPag do MDF-e

### DIFF
--- a/MDFe.Classes/Informacoes/infBanc.cs
+++ b/MDFe.Classes/Informacoes/infBanc.cs
@@ -2,11 +2,12 @@
 
 namespace MDFe.Classes.Informacoes
 {
-    [Serializable]
-    public class infBanc
-    {
-        public string codBanco { get; set; }
-        public string codAgencia { get; set; }
-        public string CNPJIPEF { get; set; }
-    }
+	[Serializable]
+	public class infBanc
+	{
+		public string codBanco { get; set; }
+		public string codAgencia { get; set; }
+		public string CNPJIPEF { get; set; }
+		public string PIX { get; set; }
+	}
 }


### PR DESCRIPTION
### Descrição
Adiciona o campo **PIX** no grupo `infBanc` dentro de `infPag` do MDF-e.

Campo opcional para informar a chave PIX como forma de pagamento.

### Documentação
Segue print da documentação oficial mostrando o uso do campo PIX.

<img width="690" height="341" alt="image" src="https://github.com/user-attachments/assets/b9be25c3-2849-454a-ada9-3278c555e432" />
