### PR TITLE
Fix html tags

### DIFF
--- a/DFe.Utils/FuncoesXml.cs
+++ b/DFe.Utils/FuncoesXml.cs
@@ -13,6 +13,8 @@ namespace DFe.Utils
 
         // https://github.com/ZeusAutomacao/DFe.NET/issues/610
         private static readonly Hashtable CacheSerializers = new Hashtable();
+        private static XNamespace ns = "http://www.portalfiscal.inf.br/nfe";
+
 
         /// <summary>
         ///     Serializa a classe passada para uma string no form
@@ -193,6 +195,13 @@ namespace DFe.Utils
         {
             var s = stringXml;
             var xmlDoc = XDocument.Parse(s);
+
+            foreach (var infCpl in xmlDoc.Descendants(ns + "infCpl"))
+            {
+                // Remove nós filhos (ex.: <br/>) e mantém só o texto
+                infCpl.ReplaceNodes(new XText(infCpl.Value));
+            }
+
             var xmlString = (from d in xmlDoc.Descendants()
                              where d.Name.LocalName == nomeDoNode
                              select d).FirstOrDefault();

--- a/NFe.Utils/NFe/ExtNFe.cs
+++ b/NFe.Utils/NFe/ExtNFe.cs
@@ -17,10 +17,10 @@ namespace NFe.Utils.NFe
         /// <param name="nfe"></param>
         /// <param name="arquivoXml">arquivo XML</param>
         /// <returns>Retorna uma NFe carregada com os dados do XML</returns>
-        public static Classes.NFe CarregarDeArquivoXml(this Classes.NFe nfe, string arquivoXml)
+        public static Classes.NFe CarregarDeArquivoXml(this Classes.NFe nfe, string arquivoXml, bool ignorarOrdenacaoElementos = false)
         {
             var s = FuncoesXml.ObterNodeDeArquivoXml(typeof (Classes.NFe).Name, arquivoXml);
-            return FuncoesXml.XmlStringParaClasse<Classes.NFe>(s);
+            return FuncoesXml.XmlStringParaClasse<Classes.NFe>(s, ignorarOrdenacaoElementos);
         }
 
         /// <summary>
@@ -39,10 +39,10 @@ namespace NFe.Utils.NFe
         /// <param name="nfe"></param>
         /// <param name="xmlString"></param>
         /// <returns>Retorna um objeto do tipo NFe</returns>
-        public static Classes.NFe CarregarDeXmlString(this Classes.NFe nfe, string xmlString)
+        public static Classes.NFe CarregarDeXmlString(this Classes.NFe nfe, string xmlString, bool ignorarOrdenacaoElementos = false)
         {
             var s = FuncoesXml.ObterNodeDeStringXml(typeof (Classes.NFe).Name, xmlString);
-            return FuncoesXml.XmlStringParaClasse<Classes.NFe>(s);
+            return FuncoesXml.XmlStringParaClasse<Classes.NFe>(s, ignorarOrdenacaoElementos);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace NFe.Utils.NFe
         {
             if (nfe == null) throw new ArgumentNullException("nfe");
 
-            var versao = (Decimal.Parse(nfe.infNFe.versao, CultureInfo.InvariantCulture));
+            var versao = Decimal.Parse(nfe.infNFe.versao, CultureInfo.InvariantCulture);
 
             var xmlNfe = nfe.ObterXmlString();
             var config = cfgServico ?? ConfiguracaoServico.Instancia;
@@ -93,7 +93,7 @@ namespace NFe.Utils.NFe
             #region Define cNF
 
             var tamanhocNf = 9;
-            var versao = (decimal.Parse(nfeLocal.infNFe.versao, CultureInfo.InvariantCulture));
+            var versao = decimal.Parse(nfeLocal.infNFe.versao, CultureInfo.InvariantCulture);
             if (versao >= 2) tamanhocNf = 8;
             nfeLocal.infNFe.ide.cNF = Convert.ToInt32(nfeLocal.infNFe.ide.cNF).ToString().PadLeft(tamanhocNf, '0');
 
@@ -121,6 +121,44 @@ namespace NFe.Utils.NFe
 
             Signature assinatura = null;
             if (_certificado == null)
+                assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, config);
+            else
+                assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, _certificado, config.Certificado.ManterDadosEmCache, config.Certificado.SignatureMethodSignedXml, config.Certificado.DigestMethodReference, config.RemoverAcentos);
+            nfeLocal.Signature = assinatura;
+            return nfeLocal;
+        }
+
+        /// <summary>
+        ///     Assina um objeto NFe
+        /// </summary>
+        /// <param name="chave"></param>
+        /// <param name="nfe"></param>
+        /// <param name="cfgServico">ConfiguracaoServico para uso na classe Assinador</param>
+        /// <returns>Retorna um objeto do tipo NFe assinado</returns>
+        public static Classes.NFe Assina(this Classes.NFe nfe, string chave, ConfiguracaoServico cfgServico = null, X509Certificate2 _certificado = null)
+        {
+            var nfeLocal = nfe;
+            if (nfeLocal is null) throw new ArgumentNullException("nfe");
+
+            var config = cfgServico ?? ConfiguracaoServico.Instancia;
+
+            #region Define cNF
+
+            var tamanhocNf = 9;
+            var versao = decimal.Parse(nfeLocal.infNFe.versao, CultureInfo.InvariantCulture);
+            if (versao >= 2) tamanhocNf = 8;
+
+            var cnf = chave.Substring(chave.Length - 10);
+            cnf = cnf.Remove(cnf.Length - 1, 1);
+            nfeLocal.infNFe.ide.cNF = cnf;
+
+            #endregion
+
+            nfeLocal.infNFe.Id = $"NFe{chave}";
+            nfeLocal.infNFe.ide.cDV = Convert.ToInt32(chave.Substring(chave.Length - 1));
+
+            Signature assinatura = null;
+            if (_certificado is null)
                 assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, config);
             else
                 assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, _certificado, config.Certificado.ManterDadosEmCache, config.Certificado.SignatureMethodSignedXml, config.Certificado.DigestMethodReference, config.RemoverAcentos);

--- a/NFe.Utils/NFe/ExtNFe.cs
+++ b/NFe.Utils/NFe/ExtNFe.cs
@@ -127,43 +127,5 @@ namespace NFe.Utils.NFe
             nfeLocal.Signature = assinatura;
             return nfeLocal;
         }
-
-        /// <summary>
-        ///     Assina um objeto NFe
-        /// </summary>
-        /// <param name="chave"></param>
-        /// <param name="nfe"></param>
-        /// <param name="cfgServico">ConfiguracaoServico para uso na classe Assinador</param>
-        /// <returns>Retorna um objeto do tipo NFe assinado</returns>
-        public static Classes.NFe Assina(this Classes.NFe nfe, string chave, ConfiguracaoServico cfgServico = null, X509Certificate2 _certificado = null)
-        {
-            var nfeLocal = nfe;
-            if (nfeLocal is null) throw new ArgumentNullException("nfe");
-
-            var config = cfgServico ?? ConfiguracaoServico.Instancia;
-
-            #region Define cNF
-
-            var tamanhocNf = 9;
-            var versao = decimal.Parse(nfeLocal.infNFe.versao, CultureInfo.InvariantCulture);
-            if (versao >= 2) tamanhocNf = 8;
-
-            var cnf = chave.Substring(chave.Length - 10);
-            cnf = cnf.Remove(cnf.Length - 1, 1);
-            nfeLocal.infNFe.ide.cNF = cnf;
-
-            #endregion
-
-            nfeLocal.infNFe.Id = $"NFe{chave}";
-            nfeLocal.infNFe.ide.cDV = Convert.ToInt32(chave.Substring(chave.Length - 1));
-
-            Signature assinatura = null;
-            if (_certificado is null)
-                assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, config);
-            else
-                assinatura = Assinador.ObterAssinatura(nfeLocal, nfeLocal.infNFe.Id, _certificado, config.Certificado.ManterDadosEmCache, config.Certificado.SignatureMethodSignedXml, config.Certificado.DigestMethodReference, config.RemoverAcentos);
-            nfeLocal.Signature = assinatura;
-            return nfeLocal;
-        }
     }
 }


### PR DESCRIPTION
Correção para remover tags HTML de dentro da tag **infCpl**.

Tive um cliente que recebeu um XML da seguinte maneira:
`<infAdic>
    <infCpl>Total aproximado de tributos: R$ 267,27 (42,22%)  Federais R$ 96,33 (15,22%)  Estaduais R$ 170,91 (27,00%) . Fonte IBPT.
					<br />
    </infCpl>
</infAdic>`

Quando eu ia fazer a deserialização, estava dando erro.
--

Portando acho pertinente essa modificação para não haver problemas para outras pessoas.
Podemos pensar em algo mais abrangente, para outras tags também.