### PR TITLE
Correção para remover tags HTML de dentro da TAG infCpl.

### DIFF
--- a/DFe.Utils/FuncoesXml.cs
+++ b/DFe.Utils/FuncoesXml.cs
@@ -13,6 +13,8 @@ namespace DFe.Utils
 
         // https://github.com/ZeusAutomacao/DFe.NET/issues/610
         private static readonly Hashtable CacheSerializers = new Hashtable();
+        private static XNamespace ns = "http://www.portalfiscal.inf.br/nfe";
+
 
         /// <summary>
         ///     Serializa a classe passada para uma string no form
@@ -193,6 +195,13 @@ namespace DFe.Utils
         {
             var s = stringXml;
             var xmlDoc = XDocument.Parse(s);
+
+            foreach (var infCpl in xmlDoc.Descendants(ns + "infCpl"))
+            {
+                // Remove nós filhos (ex.: <br/>) e mantém só o texto
+                infCpl.ReplaceNodes(new XText(infCpl.Value));
+            }
+
             var xmlString = (from d in xmlDoc.Descendants()
                              where d.Name.LocalName == nomeDoNode
                              select d).FirstOrDefault();


### PR DESCRIPTION
Correção para remover tags HTML de dentro da tag infCpl.

Tive um cliente que recebeu um XML da seguinte maneira:
`<infAdic> <infCpl>Total aproximado de tributos: R$ 267,27 (42,22%)  Federais R$ 96,33 (15,22%)  Estaduais R$ 170,91 (27,00%) . Fonte IBPT. <br /> </infCpl> </infAdic>`

Quando eu ia fazer a deserialização, estava dando erro.
Portando acho pertinente essa modificação para não haver problemas para outras pessoas.
Podemos pensar em algo mais abrangente, para outras tags também.