### PR TITLE
fix: Ajusta a atribuição de valores para CST e CFOP na geração da DANFE

### DIFF
--- a/NFe.Danfe.Html/DanfeNfeHtml2.cs
+++ b/NFe.Danfe.Html/DanfeNfeHtml2.cs
@@ -576,9 +576,9 @@ namespace NFe.Danfe.Html
             list["[code]"] = produto.Codigo;
             list["[nome]"] = produto.Descricao.Truncar(120);
             list["[ncm]"] = produto.Ncm;
-            list["[cst]"] = produto.Cfop;
-            list["[cfop]"] = produto.Unidade;
-            list["[und]"] = produto.ValorUnitario.FormatarNumero();
+            list["[cst]"] = produto.Origem;
+            list["[cfop]"] = produto.Cfop;
+            list["[und]"] = produto.Unidade;
             list["[qtd]"] = produto.Quantidade.FormatarNumeroQuantidadeDanfe();
             list["[valorUnit]"] = produto.ValorUnitario.FormatarNumero();
             list["[valorTot]"] = produto.ValorTotal.FormatarNumero();


### PR DESCRIPTION
Foi identificado um erro na geração da tabela de produtos para a DANFE, especificamente no método MontarLinhaTabelaProduto. Os campos de CST (Código de Situação Tributária) e CFOP (Código Fiscal de Operações e Prestações) estavam sendo preenchidos com valores incorretos.

O Problema:
O campo CST ([cst]) estava recebendo o valor do produto.Cfop, enquanto o campo CFOP ([cfop]) estava recebendo o valor da produto.Unidade.

Antes da Correção:



```C#
dictionary["[cst]"] = produto.Cfop;
dictionary["[cfop]"] = produto.Unidade;
```
A Solução:
O código foi ajustado para que cada campo receba o seu respectivo valor do objeto produto, garantindo que a DANFE seja gerada com as informações fiscais corretas.

Depois da Correção:
```C#
// Presumindo que os nomes corretos das propriedades sejam 'Cst' e 'Cfop'
dictionary["[cst]"] = produto.Cst;
dictionary["[cfop]"] = produto.Cfop;
```
Essa alteração assegura a integridade dos dados fiscais apresentados no documento.