### PR TITLE
[ISSUE-116] Correção de vulnerabilidades com o FastReport e System.Dr…

### DIFF
--- a/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
+++ b/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
@@ -5,9 +5,14 @@
 		
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="FastReport.OpenSource" Version="2022.2.2" />
 		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2022.2.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+		<PackageReference Include="FastReport.OpenSource" Version="2026.1.2" />
+		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2026.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
+++ b/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
@@ -5,9 +5,14 @@
 		
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="FastReport.OpenSource" Version="2022.2.2" />
 		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2022.2.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+		<PackageReference Include="FastReport.OpenSource" Version="2026.1.2" />
+		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2026.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
+++ b/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
@@ -5,9 +5,14 @@
 		
 	</PropertyGroup>
 
-	<ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="FastReport.OpenSource" Version="2022.2.2" />
 		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2022.2.2" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+		<PackageReference Include="FastReport.OpenSource" Version="2026.1.2" />
+		<PackageReference Include="FastReport.OpenSource.Export.PdfSimple" Version="2026.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Os projetos:

- CTe.Dacte.OpenFast
- MDFe.Damdfe.OpenFast
- NFe.Danfe.OpenFast

Os citados estão com a vulnerabilidade no pacote System.Drawing.Common quem vem do FastReport.OpenSource 2022.2.2. 

CVE-2021-24112, uma vulnerabilidade crítica. 

Esse issue foi criado para resolver esse problema