### PR TITLE
Refatorar a recuperação da chave de assinatura em Assinador.cs

### DIFF
--- a/NFe.Utils/Assinatura/Assinador.cs
+++ b/NFe.Utils/Assinatura/Assinador.cs
@@ -65,7 +65,14 @@ namespace NFe.Utils.Assinatura
 
                 documento.LoadXml(xml);
 
-                var docXml = new SignedXml(documento) { SigningKey = certificadoDigital.PrivateKey };
+                SignedXml docXml = new SignedXml(documento);
+
+                // Pega a chave RSA de forma "moderna", compatível com CNG e CSP
+                RSA rsa = certificadoDigital.GetRSAPrivateKey();
+                if (rsa == null)
+                    throw new Exception("O certificado não possui chave privada RSA.");
+                
+                docXml.SigningKey = rsa;
 
                 docXml.SignedInfo.SignatureMethod = signatureMethod;
 


### PR DESCRIPTION
O processo de assinatura foi atualizado para usar a chave RSA do certificado digital. Alterar para forma "moderna", compatível com provedores CNG e CSP