### PR TITLE
Adicionando suporte a .NET 10 (multitarget)

### DIFF
--- a/CTe.Classes/CTe.Classes.csproj
+++ b/CTe.Classes/CTe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/CTe.Dacte.Base/CTe.Dacte.Base.csproj
+++ b/CTe.Dacte.Base/CTe.Dacte.Base.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48'">
@@ -19,6 +19,12 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
 		<PackageReference Include="System.Drawing.Common">
 			<Version>9.0.*</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+		<PackageReference Include="System.Drawing.Common">
+			<Version>10.0.*</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
+++ b/CTe.Dacte.OpenFast/CTe.Dacte.OpenFast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<DefineConstants>openfastreport</DefineConstants>
 		
 	</PropertyGroup>

--- a/CTe.Servicos/CTe.Servicos.csproj
+++ b/CTe.Servicos/CTe.Servicos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/CTe.Utils/CTe.Utils.csproj
+++ b/CTe.Utils/CTe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/CTe.Wsdl/CTe.Wsdl.csproj
+++ b/CTe.Wsdl/CTe.Wsdl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/DFe.Classes/DFe.Classes.csproj
+++ b/DFe.Classes/DFe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	
   </PropertyGroup>
 	

--- a/DFe.Utils/DFe.Utils.csproj
+++ b/DFe.Utils/DFe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		
 	</PropertyGroup>
 

--- a/DFe.Wsdl/DFe.Wsdl.csproj
+++ b/DFe.Wsdl/DFe.Wsdl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Classes/MDFe.Classes.csproj
+++ b/MDFe.Classes/MDFe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Damdfe.Base/MDFe.Damdfe.Base.csproj
+++ b/MDFe.Damdfe.Base/MDFe.Damdfe.Base.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
 		<PackageReference Include="System.Drawing.Common">
 			<Version>6.0.0</Version>
 		</PackageReference>

--- a/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
+++ b/MDFe.Damdfe.OpenFast/MDFe.Damdfe.OpenFast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<DefineConstants>openfastreport</DefineConstants>
 		
 	</PropertyGroup>

--- a/MDFe.Servicos/MDFe.Servicos.csproj
+++ b/MDFe.Servicos/MDFe.Servicos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Utils/MDFe.Utils.csproj
+++ b/MDFe.Utils/MDFe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/MDFe.Wsdl/MDFe.Wsdl.csproj
+++ b/MDFe.Wsdl/MDFe.Wsdl.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/NFe.Classes/NFe.Classes.csproj
+++ b/NFe.Classes/NFe.Classes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 

--- a/NFe.Danfe.Base/NFe.Danfe.Base.csproj
+++ b/NFe.Danfe.Base/NFe.Danfe.Base.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="System.Drawing.Common">
       <Version>6.0.0</Version>
     </PackageReference>

--- a/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
+++ b/NFe.Danfe.Fast.Skia/NFe.Danfe.Fast.Skia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 		<DefineConstants>fastskia</DefineConstants>
 	</PropertyGroup>
 

--- a/NFe.Danfe.Nativo/NFe.Danfe.Nativo.csproj
+++ b/NFe.Danfe.Nativo/NFe.Danfe.Nativo.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0-windows;net10.0-windows</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
+++ b/NFe.Danfe.OpenFast/NFe.Danfe.OpenFast.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		<DefineConstants>openfastreport</DefineConstants>
 		
 	</PropertyGroup>

--- a/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
+++ b/NFe.Danfe.PdfClown/NFe.Danfe.PdfClown.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
 	  <LangVersion>latest</LangVersion>

--- a/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
+++ b/NFe.Danfe.QuestPdf/NFe.Danfe.QuestPdf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/NFe.Servicos/NFe.Servicos.csproj
+++ b/NFe.Servicos/NFe.Servicos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		
 	</PropertyGroup>
 
@@ -11,7 +11,7 @@
 		<ProjectReference Include="..\NFe.Wsdl\NFe.Wsdl.csproj" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' or '$(TargetFramework)' == 'net10.0'">
 		<ProjectReference Include="..\NFe.Wsdl.Standard\NFe.Wsdl.Standard.csproj" />
 	</ItemGroup>
 

--- a/NFe.Utils/NFe.Utils.csproj
+++ b/NFe.Utils/NFe.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	  <TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	  
   </PropertyGroup>
 	

--- a/NFe.Wsdl.Standard/NFe.Wsdl.Standard.csproj
+++ b/NFe.Wsdl.Standard/NFe.Wsdl.Standard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 		
 	</PropertyGroup>
 

--- a/NuGet/Hercules.NET.CTe/Hercules.NET.CTe.csproj
+++ b/NuGet/Hercules.NET.CTe/Hercules.NET.CTe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.Impressao.NFCe.QuestPdf/Hercules.NET.Impressao.NFCe.QuestPdf.csproj
+++ b/NuGet/Hercules.NET.Impressao.NFCe.QuestPdf/Hercules.NET.Impressao.NFCe.QuestPdf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.MDFe/Hercules.NET.MDFe.csproj
+++ b/NuGet/Hercules.NET.MDFe/Hercules.NET.MDFe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>

--- a/NuGet/Hercules.NET.NFe.NFCe/Hercules.NET.NFe.NFCe.csproj
+++ b/NuGet/Hercules.NET.NFe.NFCe/Hercules.NET.NFe.NFCe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0</TargetFrameworks>
+	<TargetFrameworks>net462;netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
 	<PlatformTarget>AnyCpu</PlatformTarget>
     <Configurations>Release</Configurations>
     <NoBuild>true</NoBuild>


### PR DESCRIPTION
Este PR adiciona suporte a `net10.0` (e `net10.0-windows` quando necessário) nos projetos da solução, mantendo todos os targets já existentes (`net462, netstandard2.0, net8.0, net9.0`).

A alteração é aditiva e sem breaking changes: apenas atualização de TargetFrameworks e ajustes pontuais de condições em .csproj para garantir compilação no .NET 10.

Fiz build dos projetos alterados com `-f net10.0/-f net10.0-windows` com sucesso.