### PR TITLE
Adicionando evento de cancelamento de evento de desacordo de CT-e

### DIFF
--- a/CTe.AppTeste.NetCore/Program.cs
+++ b/CTe.AppTeste.NetCore/Program.cs
@@ -111,6 +111,9 @@ namespace CTe.AppTeste.NetCore
                     case 10:
                         await EventoDesacordoCTe();
                         break;
+                    case 11:
+                        await EventoCancelaDesacordoCTe();
+                        break;
                 }
 
                 if (Convert.ToInt32(option) > 0)
@@ -366,6 +369,23 @@ namespace CTe.AppTeste.NetCore
 
             var servico = new EventoDesacordo(sequenciaEvento, chave, cnpj, indPres, obs);
             var retorno = await servico.DiscordarAsync(configuracaoServico);
+
+            OnSucessoSync(new RetornoEEnvio(retorno));
+        }
+
+        private static async Task EventoCancelaDesacordoCTe()
+        {
+            var config = new ConfiguracaoDao().BuscarConfiguracao();
+            //CarregarConfiguracoes(config);
+            var configuracaoServico = MontarConfiguracoes(config);
+
+            var cnpj = RequisitarInput("CNPJ Tomador");
+            var chave = RequisitarInput("Chave CTe");
+            var sequenciaEvento = int.Parse(RequisitarInput("Sequencia Evento"));
+            var nProtEventoDesacordo = RequisitarInput("Número do Protocolo do Evento de Desacordo");
+
+            var servico = new EventoCancelamentoDesacordo(sequenciaEvento, chave, cnpj, nProtEventoDesacordo);
+            var retorno = await servico.CancelarDesacordoAsync(configuracaoServico);
 
             OnSucessoSync(new RetornoEEnvio(retorno));
         }

--- a/CTe.AppTeste/CTeTesteModel.cs
+++ b/CTe.AppTeste/CTeTesteModel.cs
@@ -793,6 +793,22 @@ namespace CTe.AppTeste
             OnSucessoSync(new RetornoEEnvio(retorno));
         }
 
+        public void EventoCancelaDesacordoCTe()
+        {
+            var config = new ConfiguracaoDao().BuscarConfiguracao();
+            CarregarConfiguracoes(config);
+
+            var cnpj = (InputBoxTuche("CNPJ Tomador"));
+            var chave = (InputBoxTuche("Chave CTe"));
+            var sequenciaEvento = int.Parse(InputBoxTuche("Sequencia Evento"));
+            var nProtEventoDesacordo = InputBoxTuche("Número do Protocolo do Evento de Desacordo");
+
+            var servico = new EventoCancelamentoDesacordo(sequenciaEvento, chave, cnpj, nProtEventoDesacordo);
+            var retorno = servico.CancelarDesacordo();
+
+            OnSucessoSync(new RetornoEEnvio(retorno));
+        }
+
         public void CartaCorrecao()
         {
             var config = new ConfiguracaoDao().BuscarConfiguracao();

--- a/CTe.AppTeste/MainWindow.xaml
+++ b/CTe.AppTeste/MainWindow.xaml
@@ -228,6 +228,7 @@
                         <RowDefinition Height="Auto"></RowDefinition>
                         <RowDefinition Height="Auto"></RowDefinition>
                         <RowDefinition Height="Auto"></RowDefinition>
+                        <RowDefinition Height="Auto"></RowDefinition>
                         <RowDefinition Height="*"></RowDefinition>
                     </Grid.RowDefinitions>
 
@@ -243,8 +244,9 @@
                     <Button Grid.Row="4" Grid.Column="0" Click="EventoDesacordoCTe_Click" Grid.ColumnSpan="2">Evento Desacordo CT-e</Button>
                     <Button Grid.Row="5" Grid.Column="0" Click="EmitirCteOs_Click" Grid.ColumnSpan="2">Emitir CT-e OS</Button>
                     <Button Grid.Row="5" Grid.Column="2" Click="LoadXmlCte_Click" Grid.ColumnSpan="2">Load Xml CT-e</Button>
+                    <Button Grid.Row="6" Grid.Column="0" Click="EventoCancelaDesacordoCTe_Click" Grid.ColumnSpan="2">Evento Cancelar Desacordo CT-e</Button>
 
-                    <TabControl Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="3">
+                    <TabControl Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="3">
                         <TabItem Header="XmlEnvio">
                             <Grid Background="#FFE5E5E5">
                                 <WebBrowser x:Name="WebXmlEnvio" />

--- a/CTe.AppTeste/MainWindow.xaml.cs
+++ b/CTe.AppTeste/MainWindow.xaml.cs
@@ -88,6 +88,11 @@ namespace CTe.AppTeste
             _model.EventoDesacordoCTe();
         }
 
+        private void EventoCancelaDesacordoCTe_Click(object sender, RoutedEventArgs e)
+        {
+            _model.EventoCancelaDesacordoCTe();
+        }
+
         private void CartaCorrecao_Click(object sender, RoutedEventArgs e)
         {
             _model.CartaCorrecao();

--- a/CTe.Classes/Servicos/Evento/detEvento.cs
+++ b/CTe.Classes/Servicos/Evento/detEvento.cs
@@ -11,6 +11,7 @@ namespace CTe.Classes.Servicos.Evento
         [XmlElement("evCancCTe", typeof(evCancCTe), Namespace = "http://www.portalfiscal.inf.br/cte")]
         [XmlElement("evCCeCTe", typeof(evCCeCTe), Namespace = "http://www.portalfiscal.inf.br/cte")]
         [XmlElement("evPrestDesacordo", typeof(evPrestDesacordo), Namespace = "http://www.portalfiscal.inf.br/cte")]
+        [XmlElement("evCancPrestDesacordo", typeof(evCancPrestDesacordo), Namespace = "http://www.portalfiscal.inf.br/cte")]
         public EventoContainer EventoContainer { get; set; }
     }
 }

--- a/CTe.Classes/Servicos/Evento/evCancPrestDesacordo.cs
+++ b/CTe.Classes/Servicos/Evento/evCancPrestDesacordo.cs
@@ -1,0 +1,18 @@
+﻿using System.Xml.Serialization;
+
+namespace CTe.Classes.Servicos.Evento
+{
+    [XmlRoot(Namespace = "http://www.portalfiscal.inf.br/cte")]
+    public class evCancPrestDesacordo : EventoContainer
+    {
+        public evCancPrestDesacordo()
+        {
+            this.descEvento = "Cancelamento Prestação do Serviço em Desacordo";
+        }
+
+        public string descEvento { get; set; }
+
+        public string nProtEvPrestDes { get; set; }
+
+    }
+}

--- a/CTe.Servicos/ConsultaStatus/StatusServico.cs
+++ b/CTe.Servicos/ConsultaStatus/StatusServico.cs
@@ -28,6 +28,9 @@ namespace CTe.Servicos.ConsultaStatus
 
         public retConsStatServCTe ConsultaStatusV4(ConfiguracaoServico configuracaoServico = null)
         {
+            if (configuracaoServico == null)
+                configuracaoServico = ConfiguracaoServico.Instancia;
+
             var consStatServCte = ClassesFactory.CriaConsStatServCTe(configuracaoServico);
 
             if (configuracaoServico.IsValidaSchemas)

--- a/CTe.Servicos/Eventos/EventoCancelamentoDesacordo.cs
+++ b/CTe.Servicos/Eventos/EventoCancelamentoDesacordo.cs
@@ -1,0 +1,47 @@
+﻿using CTe.Classes;
+using CTe.Classes.Servicos.Evento;
+using CTe.Classes.Servicos.Evento.Flags;
+using CTe.Servicos.Factory;
+using System.Threading.Tasks;
+
+namespace CTe.Servicos.Eventos
+{
+    public class EventoCancelamentoDesacordo
+    {
+        private readonly int _sequenciaEvento;
+        private readonly string _cnpj;
+        private readonly string _chave;
+        private readonly string _nProtEvPrestDes;
+
+        public eventoCTe EventoEnviado { get; private set; }
+        public retEventoCTe RetornoSefaz { get; private set; }
+
+        public EventoCancelamentoDesacordo(int sequenciaEvento, string chave, string cnpj, string nProtEvPrestDes)
+        {
+            _chave = chave;
+            _cnpj = cnpj;
+            _sequenciaEvento = sequenciaEvento;
+            _nProtEvPrestDes = nProtEvPrestDes;
+        }
+
+        public retEventoCTe CancelarDesacordo(ConfiguracaoServico configuracaoServico = null)
+        {
+            var eventoCancelaDiscordar = ClassesFactory.CriaEvCancPrestDesacordo(_nProtEvPrestDes);
+
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configuracaoServico);
+            RetornoSefaz = new ServicoController().Executar(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configuracaoServico);
+
+            return RetornoSefaz;
+        }
+
+        public async Task<retEventoCTe> CancelarDesacordoAsync(ConfiguracaoServico configuracaoServico = null)
+        {
+            var eventoCancelaDiscordar = ClassesFactory.CriaEvCancPrestDesacordo(_nProtEvPrestDes);
+
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configuracaoServico);
+            RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configuracaoServico);
+
+            return RetornoSefaz;
+        }
+    }
+}

--- a/CTe.Servicos/Factory/ClassesFactory.cs
+++ b/CTe.Servicos/Factory/ClassesFactory.cs
@@ -131,6 +131,22 @@ namespace CTe.Servicos.Factory
 
             return evPrestDesacordo;
         }
+        public static evCancPrestDesacordo CriaEvCancPrestDesacordo(string nProtEvPrestDes, ConfiguracaoServico configuracaoServico = null)
+        {
+            var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
+
+            var evPrestDesacordo = new evCancPrestDesacordo
+            {
+                nProtEvPrestDes = nProtEvPrestDes
+            };
+
+            if (configServico.cUF == Estado.MT)//sem acentuação issue #1386
+            {
+                evPrestDesacordo.descEvento = "Cancelamento Prestacaoo do Servico em Desacordo";
+            }
+
+            return evPrestDesacordo;
+        }
 
         public static enviCTe CriaEnviCTe(int lote, List<CTeEletronica> cteEletronicoList, ConfiguracaoServico configuracaoServico = null)
         {


### PR DESCRIPTION
Adicionando a função de cancelar um evento de desacordo de CT-e. Implementei o evento 6.6 "Evento Cancelamento do Evento Prestação de Serviço em Desacordo" do _Manual de Orientação do Contribuinte Padrões Técnicos de Comunicação do CTe - Versão 4.00 – agosto 2022_.