### PR TITLE
Adicionada tag vTotDFe no CT-e Outros Serviços

### DIFF
--- a/CTe.Classes/CTeOutrosServicos/Informacoes/Impostos/impOs.cs
+++ b/CTe.Classes/CTeOutrosServicos/Informacoes/Impostos/impOs.cs
@@ -24,5 +24,21 @@ namespace CTe.CTeOSDocumento.CTe.CTeOS.Informacoes.Impostos
         public infTribFed infTribFed { get; set; }
 
         public IBSCBS IBSCBS { get; set; }
+
+        private decimal? _vTotDFe;
+        /// <summary>
+        /// O total geral do DFe deverá ser a soma do total da prestação + IBS + CBS
+        ///     vTotDFe = vPrest / vTPrest + gIBSCBS / vIBS + gCBS / vCBS
+        /// 
+        /// Exceção: Em 2026 não somar IBS e CBS
+        /// Observação: Implementação futura
+        /// </summary>
+        public decimal? vTotDFe
+        {
+            get { return _vTotDFe.Arredondar(2); }
+            set { _vTotDFe = value.Arredondar(2); }
+        }
+
+        public bool vTotDFeSpecified { get { return vTotDFe.HasValue; } }
     }
 }


### PR DESCRIPTION
Adicionada tag vTotDFe no CT-e Outros Serviços, código copiado do CT-e.

Recebi rejeição hoje sobre isso em SC/Homologação: 360 - Rejeição: Total do DFe de preenchimento obrigatório.

Parece ser exigido somente quando for informado IBS/CBS.

edit: só para adicionar uma referência. Campo mencionado em CTe_Nota_Tecnica_2025_001_RTC_v1.10.
<img width="708" height="287" alt="image" src="https://github.com/user-attachments/assets/e0d875d9-0a14-4652-83e7-54e08161a368" />
