### PR TITLE
Ajustando CTeDistDFeInteresse para seguir o mesmo padrão de NFeDistDFeInteresse

### DIFF
--- a/CTe.Classes/Servicos/DistribuicaoDFe/Schemas/procEventoCTe.cs
+++ b/CTe.Classes/Servicos/DistribuicaoDFe/Schemas/procEventoCTe.cs
@@ -31,7 +31,5 @@ namespace CTe.Classes.Servicos.DistribuicaoDFe.Schemas
         /// </summary>
         [XmlElement(Namespace = "http://www.portalfiscal.inf.br/cte")]
         public retEventoCTe retEventoCTe { get; set; }
-
-
     }
 }

--- a/CTe.Classes/Servicos/DistribuicaoDFe/Schemas/resCTe.cs
+++ b/CTe.Classes/Servicos/DistribuicaoDFe/Schemas/resCTe.cs
@@ -1,0 +1,123 @@
+﻿using DFe.Utils;
+using System;
+using System.ComponentModel;
+using System.Xml.Serialization;
+
+namespace CTe.Classes.Servicos.DistribuicaoDFe.Schemas
+{
+    /// <summary>
+    /// Resumo de CT-e retornado no docZip com schema resCTe_v1.03.xsd
+    /// Ref: NT 2015/002 - CTeDistribuicaoDFe
+    /// </summary>
+    [Serializable()]
+    [DesignerCategory("code")]
+    [XmlType(AnonymousType = true, Namespace = "http://www.portalfiscal.inf.br/cte")]
+    [XmlRoot(Namespace = "http://www.portalfiscal.inf.br/cte", IsNullable = false)]
+    public class resCTe
+    {
+        /// <summary>
+        /// Chave de acesso do CT-e (44 dígitos)
+        /// </summary>
+        [XmlElement("chCTe")]
+        public string chCTe { get; set; }
+
+        /// <summary>
+        /// CNPJ do emitente (14 dígitos)
+        /// </summary>
+        [XmlElement("CNPJ")]
+        public string CNPJ { get; set; }
+
+        /// <summary>
+        /// Razão social ou nome do emitente
+        /// </summary>
+        [XmlElement("xNome")]
+        public string xNome { get; set; }
+
+        /// <summary>
+        /// Inscrição Estadual do emitente
+        /// </summary>
+        [XmlElement("IE")]
+        public string IE { get; set; }
+
+        /// <summary>
+        /// Modal do CT-e
+        /// <list>
+        /// <item>01=Rodoviário</item>
+        /// <item>02=Aéreo</item>
+        /// <item>03=Aquaviário</item>
+        /// <item>04=Ferroviário</item>
+        /// <item>05=Dutoviário</item>
+        /// <item>06=Multimodal</item>
+        /// </list>
+        /// </summary>
+        [XmlElement("modal")]
+        public string modal { get; set; }
+
+        /// <summary>
+        /// Data e hora de emissão do CT-e
+        /// </summary>
+        [XmlIgnore]
+        public DateTimeOffset dhEmi { get; set; }
+
+        [XmlElement(ElementName = "dhEmi")]
+        public string ProxydhEmi
+        {
+            get { return dhEmi.ParaDataHoraStringUtc(); }
+            set { dhEmi = DateTimeOffset.Parse(value); }
+        }
+
+        /// <summary>
+        /// Tipo do CT-e
+        /// <list>
+        /// <item>0=CT-e Normal</item>
+        /// <item>1=CT-e de Complemento de Valores</item>
+        /// <item>2=CT-e de Anulação</item>
+        /// <item>3=CT-e de Substituição</item>
+        /// </list>
+        /// </summary>
+        [XmlElement("tpCTe")]
+        public string tpCTe { get; set; }
+
+        /// <summary>
+        /// Digest value da assinatura do CT-e
+        /// </summary>
+        [XmlElement("digVal")]
+        public string digVal { get; set; }
+
+        /// <summary>
+        /// Data e hora do recebimento pelo Ambiente Nacional
+        /// </summary>
+        [XmlIgnore]
+        public DateTimeOffset dhRecbto { get; set; }
+
+        [XmlElement(ElementName = "dhRecbto")]
+        public string ProxydhRecbto
+        {
+            get { return dhRecbto.ParaDataHoraStringUtc(); }
+            set { dhRecbto = DateTimeOffset.Parse(value); }
+        }
+
+        /// <summary>
+        /// Número do protocolo de autorização
+        /// </summary>
+        [XmlElement("nProt")]
+        public string nProt { get; set; }
+
+        /// <summary>
+        /// Valor a receber pelo transportador
+        /// </summary>
+        [XmlElement("vRec")]
+        public string vRec { get; set; }
+
+        /// <summary>
+        /// Situação do CT-e
+        /// <list>
+        /// <item>100=Autorizado o uso do CT-e</item>
+        /// <item>101=Cancelamento de CT-e homologado</item>
+        /// <item>110=Uso denegado</item>
+        /// </list>
+        /// </summary>
+        [XmlElement("cSitCTe")]
+        public string cSitCTe { get; set; }
+    }
+}

--- a/CTe.Classes/Servicos/DistribuicaoDFe/loteDistDFeInt.cs
+++ b/CTe.Classes/Servicos/DistribuicaoDFe/loteDistDFeInt.cs
@@ -1,3 +1,4 @@
+using CTe.Classes.Servicos.DistribuicaoDFe.Schemas;
 using System;
 using System.ComponentModel;
 using System.Xml.Serialization;
@@ -36,5 +37,21 @@ namespace CTe.Classes.Servicos.DistribuicaoDFe
         /// </summary>
         [XmlText(DataType = "base64Binary")]
         public byte[] XmlNfe { get; set; }
+
+        #region Objetos possíveis para descompactar o conteúdo do campo XmlNfe, dependendo do valor do campo schema
+        [XmlIgnore]
+        public cteProc cteProc { get; set; }
+
+        [XmlIgnore]
+        public resCTe resCTe { get; set; }
+
+        [XmlIgnore]
+        public CTeOSDocumento.CTe.CTeOS.Retorno.cteOSProc cteOSProc { get; set; }
+
+        [XmlIgnore]
+        public Classes.Servicos.DistribuicaoDFe.Schemas.procEventoCTe procEventoCTe { get; set; }
+
+        //TO DO: Adicionar no futuro o procGTVe adicionando na versão 1.04 do schema de distribuição de DFe
+        #endregion
     }
 }

--- a/CTe.Servicos/DistribuicaoDFe/ServicoCTeDistribuicaoDFe.cs
+++ b/CTe.Servicos/DistribuicaoDFe/ServicoCTeDistribuicaoDFe.cs
@@ -63,27 +63,33 @@ namespace CTe.Servicos.DistribuicaoDFe
             {
                 for (int i = 0; i < retConsulta.loteDistDFeInt.Length; i++)
                 {
-                    string conteudo = Compressao.Unzip(retConsulta.loteDistDFeInt[i].XmlNfe).RemoverDeclaracaoXml();
+                    var loteAtual = retConsulta.loteDistDFeInt[i];
+                    string conteudo = Compressao.Unzip(loteAtual.XmlNfe).RemoverDeclaracaoXml();
                     string chCTe = string.Empty;
 
                     if (conteudo.StartsWith("<cteProc"))
                     {
-                        var retConteudo = FuncoesXml.XmlStringParaClasse<CTe.Classes.cteProc>(conteudo);
-                        chCTe = retConteudo.protCTe.infProt.chCTe;
+                        var cteConteudo = FuncoesXml.XmlStringParaClasse<CTe.Classes.cteProc>(conteudo);
+                        chCTe = cteConteudo.protCTe.infProt.chCTe;
+                        loteAtual.cteProc = cteConteudo;
                     }
                     else if (conteudo.StartsWith("<procEventoCTe"))
                     {
                         var procEventoNFeConteudo = FuncoesXml.XmlStringParaClasse<Classes.Servicos.DistribuicaoDFe.Schemas.procEventoCTe>(conteudo);
                         chCTe = procEventoNFeConteudo.eventoCTe.infEvento.chCTe;
+                        loteAtual.procEventoCTe = procEventoNFeConteudo;
                     }
                     else if (conteudo.StartsWith("<cteOSProc"))
                     {
-                        var retConteudo = FuncoesXml.XmlStringParaClasse<CTe.CTeOSDocumento.CTe.CTeOS.Retorno.cteOSProc>(conteudo);
-                        chCTe = retConteudo.protCTe.infProt.chCTe;
+                        var cteOSConteudo = FuncoesXml.XmlStringParaClasse<CTe.CTeOSDocumento.CTe.CTeOS.Retorno.cteOSProc>(conteudo);
+                        chCTe = cteOSConteudo.protCTe.infProt.chCTe;
+                        loteAtual.cteOSProc = cteOSConteudo;
                     }
-                    else
+                    else if (conteudo.StartsWith("<resCTe"))
                     {
-
+                        var resCTeConteudo = FuncoesXml.XmlStringParaClasse<Classes.Servicos.DistribuicaoDFe.Schemas.resCTe>(conteudo);
+                        chCTe = resCTeConteudo.chCTe;
+                        loteAtual.resCTe = resCTeConteudo;
                     }
 
                     string[] schema = retConsulta.loteDistDFeInt[i].schema.Split('_');


### PR DESCRIPTION
- Adicionando a classe de retorno de resumo de status de um CTe, o objeto **resCTe**
- Ajustando o **CTeDistDFeInteresse** para preencher referência do respectivo tipo de objeto convertido do campo **XmlNFe** (assim como ja ocorria em **NFeDistDFeInteresse**). Antes, realizava a conversão e perdia a referência, o que obrigava a converter novamente o XmlNFe no objeto de interesse, gerando um gasto desnecessário de processamento.