### PR TITLE
Ajuste na exportação pdf do fast report

### DIFF
--- a/NFe.Danfe.Fast.Skia/DanfeFastBase.cs
+++ b/NFe.Danfe.Fast.Skia/DanfeFastBase.cs
@@ -19,6 +19,7 @@ namespace NFe.Danfe.Fast.Skia
             Relatorio.Prepare();
             Relatorio.Export(new PDFExport(), arquivo);
         }
+        
         /// <summary>
         /// Converte o DANFE para PDF e copia para o stream
         /// </summary>
@@ -37,6 +38,27 @@ namespace NFe.Danfe.Fast.Skia
             }
         }
 
+        /// <summary>
+        /// Converte o DANFE para PDF retorna como byte[]
+        /// </summary>
+        public byte[] ExportarPdf()
+        {
+            using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
+            {
+                try
+                {
+                    Relatorio.Prepare();
+                    Relatorio.Export(new PDFExport(), stream);
+                    return stream.ToArray();
+                }
+                catch (System.Exception ex)
+                {
+                    throw ex;
+                }
+            }
+        }
+
+        
         /// <summary>
         /// Converte o DANFE para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
@@ -65,7 +87,28 @@ namespace NFe.Danfe.Fast.Skia
             Relatorio.Export(exportBase, outputStream);
             outputStream.Position = 0;
         }
-
+        
+        /// <summary>
+        /// Converte o DANFE para PDF retorna como byte[]
+        /// </summary>
+        /// <param name="exportBase">Instancia do tipo de exportacao do FastReport</param>
+        public byte[] ExportarPdf(FastReport.Export.ExportBase exportBase)
+        {
+            using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
+            {
+                try
+                {
+                    Relatorio.Prepare();
+                    Relatorio.Export(exportBase, stream);
+                    return stream.ToArray();
+                }
+                catch (System.Exception ex)
+                {
+                    throw ex;
+                }
+            }
+        }
+        
         public byte[] ExportarHtml()
         {
             using (MemoryStream stream = new MemoryStream()) // Create a stream for the report

--- a/NFe.Danfe.OpenFast/DanfeOpenFastBase.cs
+++ b/NFe.Danfe.OpenFast/DanfeOpenFastBase.cs
@@ -40,6 +40,26 @@ namespace NFe.Danfe.OpenFast
         }
 
         /// <summary>
+        /// Converte o DANFE para PDF retorna como byte[]
+        /// </summary>
+        public byte[] ExportarPdf()
+        {
+            using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
+            {
+                try
+                {
+                    Relatorio.Prepare();
+                    Relatorio.Export(new PDFSimpleExport(), stream);
+                    return stream.ToArray();
+                }
+                catch (System.Exception ex)
+                {
+                    throw ex;
+                }
+            }
+        }
+        
+        /// <summary>
         /// Converte o DANFE para PDF e salva-o no caminho/arquivo indicado
         /// </summary>
         /// <param name="arquivo">Caminho/arquivo onde deve ser salvo o PDF do DANFE</param>
@@ -68,14 +88,18 @@ namespace NFe.Danfe.OpenFast
             outputStream.Position = 0;
         }
 
-        public byte[] ExportarPdf()
+        /// <summary>
+        /// Converte o DANFE para PDF retorna como byte[]
+        /// </summary>
+        /// <param name="exportBase">Instancia do tipo de exportacao do FastReport</param>
+        public byte[] ExportarPdf(FastReport.Export.ExportBase exportBase)
         {
             using (MemoryStream stream = new MemoryStream()) // Create a stream for the report
             {
                 try
                 {
                     Relatorio.Prepare();
-                    Relatorio.Export(new PDFSimpleExport(), stream);
+                    Relatorio.Export(exportBase, stream);
                     return stream.ToArray();
                 }
                 catch (System.Exception ex)


### PR DESCRIPTION
A exportação de pdf do fast report estava faltando uma sobrecarga para exportação para byte array recebendo a Instancia do fastreport como parâmetro, assim como já tinha para exportação para stream e para arquivo.