### PR TITLE
Inclusão dos campos da NT 2022.002 v1.30 para ICMS CST 20 e 90

### DIFF
--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
@@ -1,13 +1,16 @@
-using NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
 using System.Xml.Serialization;
+using hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalhe.Tributacao.Estadual.Tipos;
 
-namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
+namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalhe.Tributacao.Estadual
 {
     public class ICMS90 : ICMSBasico
     {
         private decimal? _vBc;
         private decimal? _pRedBc;
         private decimal? _pIcms;
+        private decimal? _vICMSOp;
+        private decimal? _pDif;
+        private decimal? _vICMSDif;
         private decimal? _vIcms;
         private decimal? _pMvast;
         private decimal? _pRedBcst;
@@ -18,6 +21,9 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         private decimal? _vBcfcp;
         private decimal? _pFcp;
         private decimal? _vFcp;
+        private decimal? _pFcpDif;
+        private decimal? _vFcpDif;
+        private decimal? _vFcpEfet;
         private decimal? _vBcfcpst;
         private decimal? _pFcpst;
         private decimal? _vFcpst;
@@ -62,9 +68,20 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         }
 
         /// <summary>
-        ///     N16 - Alíquota do imposto
+        ///     N14a - Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.
         /// </summary>
         [XmlElement(Order = 6)]
+        public string? cBenefRBC { get; set; }
+
+        public bool ShouldSerializecBenefRBC()
+        {
+            return !string.IsNullOrWhiteSpace(cBenefRBC);
+        }
+
+        /// <summary>
+        ///     N16 - Alíquota do imposto
+        /// </summary>
+        [XmlElement(Order = 7)]
         public decimal? pICMS
         {
             get { return _pIcms.Arredondar(4); }
@@ -72,9 +89,54 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         }
 
         /// <summary>
+        ///     N16b - Valor do ICMS da Operação
+        /// </summary>
+        [XmlElement(Order = 8)]
+        public decimal? vICMSOp
+        {
+            get { return _vICMSOp.Arredondar(2); }
+            set { _vICMSOp = value.Arredondar(2); }
+        }
+
+        public bool ShouldSerializevICMSOp()
+        {
+            return vICMSOp.HasValue;
+        }
+
+        /// <summary>
+        ///     N16c - Percentual do diferimento
+        /// </summary>
+        [XmlElement(Order = 9)]
+        public decimal? pDif
+        {
+            get { return _pDif.Arredondar(4); }
+            set { _pDif = value.Arredondar(4); }
+        }
+
+        public bool ShouldSerializepDif()
+        {
+            return pDif.HasValue;
+        }
+
+        /// <summary>
+        ///     N16d - Valor do ICMS diferido
+        /// </summary>
+        [XmlElement(Order = 10)]
+        public decimal? vICMSDif
+        {
+            get { return _vICMSDif.Arredondar(2); }
+            set { _vICMSDif = value.Arredondar(2); }
+        }
+
+        public bool ShouldSerializevICMSDif()
+        {
+            return vICMSDif.HasValue;
+        }
+
+        /// <summary>
         ///     N17 - Valor do ICMS
         /// </summary>
-        [XmlElement(Order = 7)]
+        [XmlElement(Order = 11)]
         public decimal? vICMS
         {
             get { return _vIcms.Arredondar(2); }
@@ -85,7 +147,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17a - Valor da Base de Cálculo do FCP
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 8)]
+        [XmlElement(Order = 12)]
         public decimal? vBCFCP
         {
             get { return _vBcfcp.Arredondar(2); }
@@ -101,7 +163,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17b - Percentual do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 9)]
+        [XmlElement(Order = 13)]
         public decimal? pFCP
         {
             get { return _pFcp.Arredondar(4); }
@@ -117,7 +179,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N17c - Valor do Fundo de Combate à Pobreza (FCP)
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 10)]
+        [XmlElement(Order = 14)]
         public decimal? vFCP
         {
             get { return _vFcp.Arredondar(2); }
@@ -130,15 +192,63 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         }
 
         /// <summary>
+        ///     N17.4 - Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP)
+        ///     Grupo opcional N17.2
+        /// </summary>
+        [XmlElement(Order = 15)]
+        public decimal? pFCPDif
+        {
+            get { return _pFcpDif.Arredondar(4); }
+            set { _pFcpDif = value.Arredondar(4); }
+        }
+
+        public bool ShouldSerializepFCPDif()
+        {
+            return pFCPDif.HasValue;
+        }
+
+        /// <summary>
+        ///     N17e - Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido
+        ///     Grupo opcional N17.2
+        /// </summary>
+        [XmlElement(Order = 16)]
+        public decimal? vFCPDif
+        {
+            get { return _vFcpDif.Arredondar(2); }
+            set { _vFcpDif = value.Arredondar(2); }
+        }
+
+        public bool ShouldSerializevFCPDif()
+        {
+            return vFCPDif.HasValue;
+        }
+
+        /// <summary>
+        ///     N17f - Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP) realmente devido
+        ///     Grupo opcional N17.1
+        /// </summary>
+        [XmlElement(Order = 17)]
+        public decimal? vFCPEfet
+        {
+            get { return _vFcpEfet.Arredondar(2); }
+            set { _vFcpEfet = value.Arredondar(2); }
+        }
+
+        public bool ShouldSerializevFCPEfet()
+        {
+            return vFCPEfet.HasValue;
+        }
+
+        /// <summary>
         ///     N18 - Modalidade de determinação da BC do ICMS ST
         /// </summary>
-        [XmlElement(Order = 11)]
+        [XmlElement(Order = 18)]
         public DeterminacaoBaseIcmsSt? modBCST { get; set; }
 
         /// <summary>
         ///     N19 - Percentual da margem de valor Adicionado do ICMS ST
         /// </summary>
-        [XmlElement(Order = 12)]
+        [XmlElement(Order = 19)]
         public decimal? pMVAST
         {
             get { return _pMvast.Arredondar(4); }
@@ -148,7 +258,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N20 - Percentual da Redução de BC do ICMS ST
         /// </summary>
-        [XmlElement(Order = 13)]
+        [XmlElement(Order = 20)]
         public decimal? pRedBCST
         {
             get { return _pRedBcst.Arredondar(4); }
@@ -158,7 +268,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N21 - Valor da BC do ICMS ST
         /// </summary>
-        [XmlElement(Order = 14)]
+        [XmlElement(Order = 21)]
         public decimal? vBCST
         {
             get { return _vBcst.Arredondar(2); }
@@ -168,7 +278,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N22 - Alíquota do imposto do ICMS ST
         /// </summary>
-        [XmlElement(Order = 15)]
+        [XmlElement(Order = 22)]
         public decimal? pICMSST
         {
             get { return _pIcmsst.Arredondar(4); }
@@ -178,7 +288,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N23 - Valor do ICMS ST
         /// </summary>
-        [XmlElement(Order = 16)]
+        [XmlElement(Order = 23)]
         public decimal? vICMSST
         {
             get { return _vIcmsst.Arredondar(2); }
@@ -189,7 +299,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23a - Valor da Base de Cálculo do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 17)]
+        [XmlElement(Order = 24)]
         public decimal? vBCFCPST
         {
             get { return _vBcfcpst.Arredondar(2); }
@@ -205,7 +315,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23b - Percentual do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 18)]
+        [XmlElement(Order = 25)]
         public decimal? pFCPST
         {
             get { return _pFcpst.Arredondar(4); }
@@ -221,7 +331,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N23d - Valor do FCP retido por Substituição Tributária
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 19)]
+        [XmlElement(Order = 26)]
         public decimal? vFCPST
         {
             get { return _vFcpst.Arredondar(2); }
@@ -236,7 +346,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N27a - Valor do ICMS desonerado
         /// </summary>
-        [XmlElement(Order = 20)]
+        [XmlElement(Order = 27)]
         public decimal? vICMSDeson
         {
             get { return _vIcmsDeson.Arredondar(2); }
@@ -246,21 +356,21 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// <summary>
         ///     N28 - Motivo da desoneração do ICMS
         /// </summary>
-        [XmlElement(Order = 21)]
+        [XmlElement(Order = 28)]
         public MotivoDesoneracaoIcms? motDesICMS { get; set; }
-        
+
         /// <summary>
         /// N28b - Indica se o valor do ICMS desonerado (vICMSDeson) deduz 
         /// do valor do item (vProd). (NT 2023.004) 
         /// </summary>
-        [XmlElement(Order = 22)]
+        [XmlElement(Order = 29)]
         public DeduzDesoneracaoNoProduto? indDeduzDeson { get; set; }
 
         /// <summary>
         /// N33a - Valor do ICMS- ST desonerado
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 23)]
+        [XmlElement(Order = 30)]
         public decimal? vICMSSTDeson
         {
             get { return _vICMSSTDeson.Arredondar(2); }
@@ -276,7 +386,7 @@ namespace NFe.Classes.Informacoes.Detalhe.Tributacao.Estadual
         /// N33b - Motivo da desoneração do ICMS- ST 
         /// Versão 4.00
         /// </summary>
-        [XmlElement(Order = 24)]
+        [XmlElement(Order = 31)]
         public MotivoDesoneracaoIcmsSt? motDesICMSST { get; set; }
 
         public bool ShouldSerializemotDesICMSST()

--- a/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
+++ b/NFe.Classes/Informacoes/Detalhe/Tributacao/Estadual/ICMS90.cs
@@ -73,11 +73,6 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
         [XmlElement(Order = 6)]
         public string? cBenefRBC { get; set; }
 
-        public bool ShouldSerializecBenefRBC()
-        {
-            return !string.IsNullOrWhiteSpace(cBenefRBC);
-        }
-
         /// <summary>
         ///     N16 - Alíquota do imposto
         /// </summary>
@@ -98,11 +93,6 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
             set { _vICMSOp = value.Arredondar(2); }
         }
 
-        public bool ShouldSerializevICMSOp()
-        {
-            return vICMSOp.HasValue;
-        }
-
         /// <summary>
         ///     N16c - Percentual do diferimento
         /// </summary>
@@ -111,11 +101,6 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
         {
             get { return _pDif.Arredondar(4); }
             set { _pDif = value.Arredondar(4); }
-        }
-
-        public bool ShouldSerializepDif()
-        {
-            return pDif.HasValue;
         }
 
         /// <summary>
@@ -202,11 +187,6 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
             set { _pFcpDif = value.Arredondar(4); }
         }
 
-        public bool ShouldSerializepFCPDif()
-        {
-            return pFCPDif.HasValue;
-        }
-
         /// <summary>
         ///     N17e - Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido
         ///     Grupo opcional N17.2
@@ -218,11 +198,6 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
             set { _vFcpDif = value.Arredondar(2); }
         }
 
-        public bool ShouldSerializevFCPDif()
-        {
-            return vFCPDif.HasValue;
-        }
-
         /// <summary>
         ///     N17f - Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP) realmente devido
         ///     Grupo opcional N17.1
@@ -232,11 +207,6 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
         {
             get { return _vFcpEfet.Arredondar(2); }
             set { _vFcpEfet = value.Arredondar(2); }
-        }
-
-        public bool ShouldSerializevFCPEfet()
-        {
-            return vFCPEfet.HasValue;
         }
 
         /// <summary>
@@ -462,6 +432,36 @@ namespace hypercubev2.dfe.launch.engine.Domain.Model.NFeSefaz.Informacoes.Detalh
         public bool ShouldSerializeindDeduzDeson()
         {
             return indDeduzDeson.HasValue;
+        }
+
+        public bool ShouldSerializecBenefRBC()
+        {
+            return !string.IsNullOrWhiteSpace(cBenefRBC);
+        }
+
+        public bool ShouldSerializevICMSOp()
+        {
+            return vICMSOp.HasValue;
+        }
+
+        public bool ShouldSerializepDif()
+        {
+            return pDif.HasValue;
+        }
+
+        public bool ShouldSerializepFCPDif()
+        {
+            return pFCPDif.HasValue;
+        }
+
+        public bool ShouldSerializevFCPDif()
+        {
+            return vFCPDif.HasValue;
+        }
+
+        public bool ShouldSerializevFCPEfet()
+        {
+            return vFCPEfet.HasValue;
         }
     }
 }


### PR DESCRIPTION
A Nota Técnica 2022.002 v1.30a introduz novos campos nos grupos de ICMS para NF-e/NFC-e, especificamente para o CST 90.

Esta PR adiciona os novos campos e ajusta a serialização XML conforme o leiaute atualizado da SEFAZ.