### PR TITLE
Adicionado novos meios de pagamento (23 e 24) conforme Informe Técnico 2024.002

### DIFF
--- a/NFe.Classes/Informacoes/Pagamento/pagTipos.cs
+++ b/NFe.Classes/Informacoes/Pagamento/pagTipos.cs
@@ -150,6 +150,20 @@ namespace NFe.Classes.Informacoes.Pagamento
         [XmlEnum("22")] fpPagamentoEletronicoNaoInformado = 22,
 
         /// <summary>
+        /// 23 - Pagamento Instantâneo (PIX) - Automático
+        /// </summary>
+        [Description("Pagamento Instantâneo (PIX) - Automático")]
+        [XmlEnum("23")]
+        fpPagamentoInstantaneoPIXAutomatico = 23,
+
+        /// <summary>
+        /// 24 - TEF - "Book Transfer"
+        /// </summary>
+        [Description("TEF - \"Book Transfer\"")]
+        [XmlEnum("24")]
+        fpPagamentoBookTransfer = 24,
+
+        /// <summary>
         /// 90 - Sem pagamento
         /// </summary>
         [Description("Sem pagamento")]


### PR DESCRIPTION
Incluído suporte aos novos códigos de meio de pagamento definidos no Informe Técnico 2024.002 para emissão de NF-e/NFC-e.

- Adicionado código `23` – Pagamento Instantâneo (PIX) - Automático
- Adicionado código `24` – TEF - "Book Transfer"
- Atualizada enumeração/estrutura responsável pela serialização do campo de meio/forma de pagamento