### PR TITLE
Adicionado nos Métodos para Obter Certificado de Repositório do Windows o argumento StoreLocation

### DIFF
--- a/DFe.Utils/Assinatura/CertificadoDigital.cs
+++ b/DFe.Utils/Assinatura/CertificadoDigital.cs
@@ -19,9 +19,9 @@ namespace DFe.Utils.Assinatura
         /// </summary>
         /// <param name="openFlags"></param>
         /// <returns></returns>
-        public static X509Store ObterX509Store(OpenFlags openFlags)
+        public static X509Store ObterX509Store(OpenFlags openFlags, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
-            var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            X509Store store = new X509Store(StoreName.My, storeLocation);
             store.Open(openFlags);
             return store;
         }
@@ -56,7 +56,7 @@ namespace DFe.Utils.Assinatura
         {
             try
             {
-                var certificado = new X509Certificate2(arrayBytes, senha, keyStorageFlag);
+                X509Certificate2 certificado = new X509Certificate2(arrayBytes, senha, keyStorageFlag);
                 return certificado;
             }
             catch (Exception ex)
@@ -69,12 +69,12 @@ namespace DFe.Utils.Assinatura
         /// Obtém um objeto <see cref="X509Certificate2"/> pelo serial passado no parÂmetro
         /// </summary>
         /// <returns></returns>
-        private static X509Certificate2 ObterDoRepositorio(string serial, OpenFlags opcoesDeAbertura)
+        private static X509Certificate2 ObterDoRepositorio(string serial, OpenFlags opcoesDeAbertura, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
             if (string.IsNullOrEmpty(serial))
                 throw new ArgumentException("O número de série do certificado digital não foi informado!");
             X509Certificate2 certificado = null;
-            var store = ObterX509Store(opcoesDeAbertura);
+            var store = ObterX509Store(opcoesDeAbertura, storeLocation);
             try
             {
                 foreach (var item in store.Certificates)
@@ -100,9 +100,9 @@ namespace DFe.Utils.Assinatura
         /// <param name="serial"></param>
         /// <param name="senha"></param>
         /// <returns></returns>
-        private static X509Certificate2 ObterDoRepositorioPassandoPin(string serial, string senha = null)
+        private static X509Certificate2 ObterDoRepositorioPassandoPin(string serial, string senha = null, StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
-            var certificado = ObterDoRepositorio(serial, OpenFlags.ReadOnly);
+            var certificado = ObterDoRepositorio(serial, OpenFlags.ReadOnly, storeLocation);
             if (string.IsNullOrEmpty(senha)) return certificado;
             certificado.DefinirPinParaChavePrivada(senha);
             return certificado;
@@ -154,13 +154,13 @@ namespace DFe.Utils.Assinatura
             switch (configuracaoCertificado.TipoCertificado)
             {
                 case TipoCertificado.A1Repositorio:
-                    return ObterDoRepositorio(configuracaoCertificado.Serial, OpenFlags.MaxAllowed);
+                    return ObterDoRepositorio(configuracaoCertificado.Serial, OpenFlags.MaxAllowed, configuracaoCertificado.StoreLocation);
                 case TipoCertificado.A1ByteArray:
                     return ObterDoArrayBytes(configuracaoCertificado.ArrayBytesArquivo, configuracaoCertificado.Senha, configuracaoCertificado.KeyStorageFlags);
                 case TipoCertificado.A1Arquivo:
                     return ObterDeArquivo(configuracaoCertificado.Arquivo, configuracaoCertificado.Senha, configuracaoCertificado.KeyStorageFlags);
                 case TipoCertificado.A3:
-                    return ObterDoRepositorioPassandoPin(configuracaoCertificado.Serial, configuracaoCertificado.Senha);
+                    return ObterDoRepositorioPassandoPin(configuracaoCertificado.Serial, configuracaoCertificado.Senha, configuracaoCertificado.StoreLocation);
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/DFe.Utils/CertificadoDigitalUtils.cs
+++ b/DFe.Utils/CertificadoDigitalUtils.cs
@@ -16,9 +16,9 @@ namespace DFe.Utils
         /// Exibe a lista de certificados instalados no PC e devolve o certificado selecionado
         /// </summary>
         /// <returns></returns>
-        public static X509Certificate2 ListareObterDoRepositorio()
+        public static X509Certificate2 ListareObterDoRepositorio(StoreLocation storeLocation = StoreLocation.CurrentUser)
         {
-            var store = CertificadoDigital.ObterX509Store(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly);
+            var store = CertificadoDigital.ObterX509Store(OpenFlags.OpenExistingOnly | OpenFlags.ReadOnly, storeLocation);
             var collection = store.Certificates;
             var fcollection = collection.Find(X509FindType.FindByTimeValid, DateTime.Now, true);
             var scollection = X509Certificate2UI.SelectFromCollection(fcollection, "Certificados válidos:", "Selecione o certificado que deseja usar",

--- a/DFe.Utils/ConfiguracaoCertificado.cs
+++ b/DFe.Utils/ConfiguracaoCertificado.cs
@@ -28,9 +28,11 @@ namespace DFe.Utils
         private string _cacheId;
         private byte[] _arrayBytesArquivo;
         private X509KeyStorageFlags _keyStorageFlags;
+        private StoreLocation _storeLocation;
 
         public ConfiguracaoCertificado()
         {
+            StoreLocation = StoreLocation.CurrentUser;
             KeyStorageFlags = X509KeyStorageFlags.MachineKeySet;
             SignatureMethodSignedXml = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
             DigestMethodReference = "http://www.w3.org/2000/09/xmldsig#sha1";
@@ -160,6 +162,20 @@ namespace DFe.Utils
             {
                 if (value == _keyStorageFlags) return;
                 _keyStorageFlags = value;
+            }
+        }
+
+        /// <summary>
+        ///     
+        /// </summary>
+        public StoreLocation StoreLocation
+        {
+            get { return _storeLocation; }
+            set
+            {
+                if (value == _storeLocation) 
+                    return;
+                _storeLocation = value;
             }
         }
     }


### PR DESCRIPTION
Adicionado nos Métodos para Obter Certificado de Repositório do Windows o argumento StoreLocation com padrão CurrentUser, deixando opcional a mudança como por exemplo LocalMachine, onde em casos que esteja usando API ou WebService via IIS no Windows Server.