### PR TITLE
Adicionado Schemas para Validação de CNPJ Alfanumérico, retirado validação numérica de propriedades CNPJ

### DIFF
--- a/CTe.Classes/Informacoes/autXML.cs
+++ b/CTe.Classes/Informacoes/autXML.cs
@@ -16,13 +16,12 @@ namespace CTe.Classes.Informacoes
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+                
+                cnpj = value;
             }
         }
 
@@ -34,13 +33,12 @@ namespace CTe.Classes.Informacoes
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cpf = value;
             }
         }
     }

--- a/CTe.Classes/Servicos/DistribuicaoDFe/distDFeInt.cs
+++ b/CTe.Classes/Servicos/DistribuicaoDFe/distDFeInt.cs
@@ -38,13 +38,12 @@ namespace CTe.Classes.Servicos.DistribuicaoDFe
             get { return _cNPJ; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(_cPF))
-                    _cNPJ = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(_cPF))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                _cNPJ = value;
             }
         }
 
@@ -56,13 +55,12 @@ namespace CTe.Classes.Servicos.DistribuicaoDFe
             get { return _cPF; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(_cNPJ))
-                    _cPF = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(_cNPJ))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                _cPF = value;
             }
         }
 
@@ -74,8 +72,6 @@ namespace CTe.Classes.Servicos.DistribuicaoDFe
         /// <summary>
         /// A09 - Grupo para consultar um DF-e a partir de um NSU específico
         /// </summary>
-        public consNSU consNSU { get; set; }  
-
-
+        public consNSU consNSU { get; set; } 
     }
 }

--- a/CTe.Classes/Servicos/Evento/dest.cs
+++ b/CTe.Classes/Servicos/Evento/dest.cs
@@ -27,13 +27,12 @@ namespace CTe.Classes.Servicos.Evento
             get { return _cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CPF) & string.IsNullOrEmpty(idEstrangeiro))
-                    _cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(CPF) || !string.IsNullOrEmpty(idEstrangeiro))
                     throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
-                }
+                
+                _cnpj = value;
             }
         }
 
@@ -45,13 +44,12 @@ namespace CTe.Classes.Servicos.Evento
             get { return _cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CNPJ) & string.IsNullOrEmpty(idEstrangeiro))
-                    _cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(idEstrangeiro))
                     throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
-                }
+
+                _cpf = value;
             }
         }
 
@@ -63,13 +61,12 @@ namespace CTe.Classes.Servicos.Evento
             get { return _idEstrangeiro; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CNPJ) & string.IsNullOrEmpty(CPF))
-                    _idEstrangeiro = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(CPF))
                     throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
-                }
+
+                _idEstrangeiro = value;
             }
         }
 

--- a/NFe.AppTeste/MainWindow.xaml.cs
+++ b/NFe.AppTeste/MainWindow.xaml.cs
@@ -1431,7 +1431,8 @@ namespace NFe.AppTeste
         {
             var dest = new dest(versao)
             {
-                CNPJ = "99999999000191",
+                CNPJ = "0ZEN3MS8000127",
+                //CNPJ = "99999999000191",
                 //CPF = "99999999999",
             };
             dest.xNome = "NF-E EMITIDA EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL"; //Obrigatório para NFe e opcional para NFCe

--- a/NFe.AppTeste/Schemas/DFeTiposBasicos_v1.00.xsd
+++ b/NFe.AppTeste/Schemas/DFeTiposBasicos_v1.00.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 	<xs:simpleType name="TStringRTC">
 		<xs:annotation>
@@ -28,7 +28,16 @@
 			<xs:pattern value="\d{6}"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TDec1104">
+	<xs:simpleType name="TcCredPres">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação do Crédito Presumido do IBS e da CBS, conforme tabela cCredPres</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1104RTC">
 		<xs:annotation>
 			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
 		</xs:annotation>
@@ -37,7 +46,7 @@
 			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TDec_1104Op">
+	<xs:simpleType name="TDec_1104OpRTC">
 		<xs:annotation>
 			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
 		</xs:annotation>
@@ -46,7 +55,7 @@
 			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TDec1302">
+	<xs:simpleType name="TDec1302RTC">
 		<xs:annotation>
 			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
 		</xs:annotation>
@@ -55,7 +64,7 @@
 			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="TDec_0302_04">
+	<xs:simpleType name="TDec_0302_04RTC">
 		<xs:annotation>
 			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
 		</xs:annotation>
@@ -98,6 +107,14 @@
 			<xs:enumeration value="4"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:simpleType name="TIndDoacao">
+		<xs:annotation>
+			<xs:documentation>Tipo Indicador de Doação</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
 	<xs:complexType name="TTribNFCom">
 		<xs:annotation>
 			<xs:documentation>Grupo de informações da Tributação da NFCom</xs:documentation>
@@ -109,7 +126,17 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="TTribNF3e">
@@ -123,7 +150,37 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFAg">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFAg</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="TTribCTe">
@@ -137,7 +194,13 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
 			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="TTribBPe">
@@ -151,7 +214,13 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
 			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="TTribNFCe">
@@ -165,6 +234,11 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:choice minOccurs="0">
 				<xs:element name="gIBSCBS" type="TCIBS"/>
 				<xs:element name="gIBSCBSMono" type="TMonofasia"/>
@@ -182,11 +256,16 @@
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:choice minOccurs="0">
 				<xs:element name="gIBSCBS" type="TCIBS"/>
 				<xs:element name="gIBSCBSMono" type="TMonofasia">
 					<xs:annotation>
-						<xs:documentation>Informar essa opção da Choice para Monofasia</xs:documentation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia (CST 620)</xs:documentation>
 					</xs:annotation>
 				</xs:element>
 				<xs:element name="gTransfCred" type="TTransfCred">
@@ -194,10 +273,54 @@
 						<xs:documentation>Informar essa opção da Choice para o CST 800</xs:documentation>
 					</xs:annotation>
 				</xs:element>
+				<xs:element name="gAjusteCompet" type="TAjusteCompet">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 811</xs:documentation>
+					</xs:annotation>
+				</xs:element>
 			</xs:choice>
-			<xs:element name="gCredPresIBSZFM" type="TCredPresIBSZFM" minOccurs="0">
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
 				<xs:annotation>
-					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gCredPresOper" type="TCredPresOper">
+					<xs:annotation>
+						<xs:documentation>Crédito Presumido da Operação. Informado conforme indicador no cClassTrib.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gCredPresIBSZFM" type="TCredPresIBSZFM">
+					<xs:annotation>
+						<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM. Informado conforme indicador no cClassTrib.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFGas">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFGas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -214,17 +337,17 @@
 			</xs:element>
 			<xs:element name="cClassTribIS" type="TcClassTrib"/>
 			<xs:sequence minOccurs="0">
-				<xs:element name="vBCIS" type="TDec1302">
+				<xs:element name="vBCIS" type="TDec1302RTC">
 					<xs:annotation>
 						<xs:documentation>Valor do BC</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="pIS" type="TDec_0302_04">
+				<xs:element name="pIS" type="TDec_0302_04RTC">
 					<xs:annotation>
 						<xs:documentation>Alíquota do Imposto Seletivo (percentual)</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="pISEspec" type="TDec_0302_04" minOccurs="0">
+				<xs:element name="pISEspec" type="TDec_0302_04RTC" minOccurs="0">
 					<xs:annotation>
 						<xs:documentation>Alíquota do Imposto Seletivo (por valor)</xs:documentation>
 					</xs:annotation>
@@ -241,13 +364,13 @@
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:element>
-					<xs:element name="qTrib" type="TDec_1104Op">
+					<xs:element name="qTrib" type="TDec_1104OpRTC">
 						<xs:annotation>
 							<xs:documentation>Quantidade com abse no campo uTrib informado</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>
-				<xs:element name="vIS" type="TDec1302">
+				<xs:element name="vIS" type="TDec1302RTC">
 					<xs:annotation>
 						<xs:documentation>Valor do Imposto Seletivo calculado</xs:documentation>
 					</xs:annotation>
@@ -260,7 +383,7 @@
 			<xs:documentation>Grupo de informações de totais do Imposto Seletivo</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="vIS" type="TDec1302">
+			<xs:element name="vIS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor Total do Imposto Seletivo</xs:documentation>
 				</xs:annotation>
@@ -272,7 +395,7 @@
 			<xs:documentation>Grupo de informações de totais da CBS/IBS</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="vBCIBSCBS" type="TDec1302">
+			<xs:element name="vBCIBSCBS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Total Base de Calculo</xs:documentation>
 				</xs:annotation>
@@ -289,17 +412,17 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="vDif" type="TDec1302">
+									<xs:element name="vDif" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total do Diferimento</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vDevTrib" type="TDec1302">
+									<xs:element name="vDevTrib" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total de devoluções de tributos</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vIBSUF" type="TDec1302">
+									<xs:element name="vIBSUF" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
 										</xs:annotation>
@@ -313,17 +436,17 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="vDif" type="TDec1302">
+									<xs:element name="vDif" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total do Diferimento</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vDevTrib" type="TDec1302">
+									<xs:element name="vDevTrib" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total de devoluções de tributos</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vIBSMun" type="TDec1302">
+									<xs:element name="vIBSMun" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
 										</xs:annotation>
@@ -331,19 +454,9 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="vIBS" type="TDec1302">
+						<xs:element name="vIBS" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total do IBS</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="vCredPres" type="TDec1302">
-							<xs:annotation>
-								<xs:documentation>Total do Crédito Presumido</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element name="vCredPresCondSus" type="TDec1302">
-							<xs:annotation>
-								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -355,29 +468,38 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="vDif" type="TDec1302">
+						<xs:element name="vDif" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total do Diferimento</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vDevTrib" type="TDec1302">
+						<xs:element name="vDevTrib" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total de devoluções de tributos</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBS" type="TDec1302">
+						<xs:element name="vCBS" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total da CBS</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCredPres" type="TDec1302">
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do estorno de crédito</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSEstCred" type="TDec1302RTC">
 							<xs:annotation>
-								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+								<xs:documentation>Valor total do IBS estornado</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCredPresCondSus" type="TDec1302">
+						<xs:element name="vCBSEstCred" type="TDec1302RTC">
 							<xs:annotation>
-								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+								<xs:documentation>Valor total da CBS estornada</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -390,7 +512,7 @@
 			<xs:documentation>Grupo de informações de totais da CBS/IBS com monofasia</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="vBCIBSCBS" type="TDec1302">
+			<xs:element name="vBCIBSCBS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Total Base de Calculo</xs:documentation>
 				</xs:annotation>
@@ -407,17 +529,17 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="vDif" type="TDec1302">
+									<xs:element name="vDif" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total do Diferimento</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vDevTrib" type="TDec1302">
+									<xs:element name="vDevTrib" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total de devoluções de tributos</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vIBSUF" type="TDec1302">
+									<xs:element name="vIBSUF" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
 										</xs:annotation>
@@ -431,17 +553,17 @@
 							</xs:annotation>
 							<xs:complexType>
 								<xs:sequence>
-									<xs:element name="vDif" type="TDec1302">
+									<xs:element name="vDif" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total do Diferimento</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vDevTrib" type="TDec1302">
+									<xs:element name="vDevTrib" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Total de devoluções de tributos</xs:documentation>
 										</xs:annotation>
 									</xs:element>
-									<xs:element name="vIBSMun" type="TDec1302">
+									<xs:element name="vIBSMun" type="TDec1302RTC">
 										<xs:annotation>
 											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
 										</xs:annotation>
@@ -449,17 +571,17 @@
 								</xs:sequence>
 							</xs:complexType>
 						</xs:element>
-						<xs:element name="vIBS" type="TDec1302">
+						<xs:element name="vIBS" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total do IBS</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCredPres" type="TDec1302">
+						<xs:element name="vCredPres" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total do Crédito Presumido</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCredPresCondSus" type="TDec1302">
+						<xs:element name="vCredPresCondSus" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
 							</xs:annotation>
@@ -473,27 +595,27 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="vDif" type="TDec1302">
+						<xs:element name="vDif" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total do Diferimento</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vDevTrib" type="TDec1302">
+						<xs:element name="vDevTrib" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total de devoluções de tributos</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBS" type="TDec1302">
+						<xs:element name="vCBS" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total da CBS</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCredPres" type="TDec1302">
+						<xs:element name="vCredPres" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total do Crédito Presumido</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCredPresCondSus" type="TDec1302">
+						<xs:element name="vCredPresCondSus" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
 							</xs:annotation>
@@ -508,34 +630,53 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="vIBSMono" type="TDec1302">
+						<xs:element name="vIBSMono" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total do IBS monofásico</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMono" type="TDec1302">
+						<xs:element name="vCBSMono" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total da CBS monofásica</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vIBSMonoReten" type="TDec1302">
+						<xs:element name="vIBSMonoReten" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total do IBS monofásico sujeito a retenção</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMonoReten" type="TDec1302">
+						<xs:element name="vCBSMonoReten" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor total da CBS monofásica sujeita a retenção</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vIBSMonoRet" type="TDec1302">
+						<xs:element name="vIBSMonoRet" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor do IBS monofásico retido anteriormente</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMonoRet" type="TDec1302">
+						<xs:element name="vCBSMonoRet" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor da CBS monofásica retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do estorno de crédito</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS estornado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS estornada</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 					</xs:sequence>
@@ -557,27 +698,27 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="qBCMono" type="TDec_1104Op">
+						<xs:element name="qBCMono" type="TDec1104RTC">
 							<xs:annotation>
 								<xs:documentation>Quantidade tributada na monofasia</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="adRemIBS" type="TDec_0302_04">
+						<xs:element name="adRemIBS" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Alíquota ad rem do IBS</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="adRemCBS" type="TDec_0302_04">
+						<xs:element name="adRemCBS" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Alíquota ad rem da CBS</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vIBSMono" type="TDec1302">
+						<xs:element name="vIBSMono" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor do IBS monofásico</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMono" type="TDec1302">
+						<xs:element name="vCBSMono" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor da CBS monofásica</xs:documentation>
 							</xs:annotation>
@@ -591,27 +732,27 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="qBCMonoReten" type="TDec_1104Op">
+						<xs:element name="qBCMonoReten" type="TDec1104RTC">
 							<xs:annotation>
 								<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="adRemIBSReten" type="TDec_0302_04">
+						<xs:element name="adRemIBSReten" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Alíquota ad rem do IBS sujeito a retenção</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vIBSMonoReten" type="TDec1302">
+						<xs:element name="vIBSMonoReten" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor do IBS monofásico sujeito a retenção</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="adRemCBSReten" type="TDec_0302_04">
+						<xs:element name="adRemCBSReten" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Alíquota ad rem da CBS sujeita a retenção</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMonoReten" type="TDec1302">
+						<xs:element name="vCBSMonoReten" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor da CBS monofásica sujeita a retenção</xs:documentation>
 							</xs:annotation>
@@ -625,27 +766,27 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="qBCMonoRet" type="TDec_1104Op">
+						<xs:element name="qBCMonoRet" type="TDec1104RTC">
 							<xs:annotation>
 								<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="adRemIBSRet" type="TDec_0302_04">
+						<xs:element name="adRemIBSRet" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Alíquota ad rem do IBS retido anteriormente</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vIBSMonoRet" type="TDec1302">
+						<xs:element name="vIBSMonoRet" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor do IBS retido anteriormente</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="adRemCBSRet" type="TDec_0302_04">
+						<xs:element name="adRemCBSRet" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Alíquota ad rem da CBS retida anteriormente</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMonoRet" type="TDec1302">
+						<xs:element name="vCBSMonoRet" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor da CBS retida anteriormente</xs:documentation>
 							</xs:annotation>
@@ -659,22 +800,22 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="pDifIBS" type="TDec_0302_04">
+						<xs:element name="pDifIBS" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vIBSMonoDif" type="TDec1302">
+						<xs:element name="vIBSMonoDif" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor do IBS monofásico diferido</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="pDifCBS" type="TDec1302">
+						<xs:element name="pDifCBS" type="TDec_0302_04RTC">
 							<xs:annotation>
 								<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBSMonoDif" type="TDec1302">
+						<xs:element name="vCBSMonoDif" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor da CBS monofásica diferida</xs:documentation>
 							</xs:annotation>
@@ -682,12 +823,12 @@
 					</xs:sequence>
 				</xs:complexType>
 			</xs:element>
-			<xs:element name="vTotIBSMonoItem" type="TDec1302">
+			<xs:element name="vTotIBSMonoItem" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Total de IBS monofásico do item</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vTotCBSMonoItem" type="TDec1302">
+			<xs:element name="vTotCBSMonoItem" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Total da CBS monofásica do item</xs:documentation>
 				</xs:annotation>
@@ -702,7 +843,7 @@
 			<xs:annotation>
 				<xs:documentation>IBS / CBS</xs:documentation>
 			</xs:annotation>
-			<xs:element name="vBC" type="TDec1302">
+			<xs:element name="vBC" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do BC</xs:documentation>
 				</xs:annotation>
@@ -714,9 +855,9 @@
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="pIBSUF" type="TDec_0302_04">
+							<xs:element name="pIBSUF" type="TDec_0302_04RTC">
 								<xs:annotation>
-									<xs:documentation>Aliquota do IBS de competência das UF</xs:documentation>
+									<xs:documentation>Aliquota do IBS de competência das UF (em percentual)</xs:documentation>
 								</xs:annotation>
 							</xs:element>
 							<xs:element name="gDif" type="TDif" minOccurs="0">
@@ -734,7 +875,7 @@
 									<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
 								</xs:annotation>
 							</xs:element>
-							<xs:element name="vIBSUF" type="TDec1302">
+							<xs:element name="vIBSUF" type="TDec1302RTC">
 								<xs:annotation>
 									<xs:documentation>Valor do IBS de competência das UF</xs:documentation>
 								</xs:annotation>
@@ -748,9 +889,9 @@
 					</xs:annotation>
 					<xs:complexType>
 						<xs:sequence>
-							<xs:element name="pIBSMun" type="TDec_0302_04">
+							<xs:element name="pIBSMun" type="TDec_0302_04RTC">
 								<xs:annotation>
-									<xs:documentation>Aliquota do IBS Municipal</xs:documentation>
+									<xs:documentation>Aliquota do IBS Municipal (em percentual)</xs:documentation>
 								</xs:annotation>
 							</xs:element>
 							<xs:element name="gDif" type="TDif" minOccurs="0">
@@ -768,7 +909,7 @@
 									<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
 								</xs:annotation>
 							</xs:element>
-							<xs:element name="vIBSMun" type="TDec1302">
+							<xs:element name="vIBSMun" type="TDec1302RTC">
 								<xs:annotation>
 									<xs:documentation>Valor do IBS Municipal</xs:documentation>
 								</xs:annotation>
@@ -776,7 +917,7 @@
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>
-				<xs:element name="vIBS" type="TDec1302">
+				<xs:element name="vIBS" type="TDec1302RTC">
 					<xs:annotation>
 						<xs:documentation>Valor do IBS</xs:documentation>
 					</xs:annotation>
@@ -788,9 +929,9 @@
 				</xs:annotation>
 				<xs:complexType>
 					<xs:sequence>
-						<xs:element name="pCBS" type="TDec_0302_04">
+						<xs:element name="pCBS" type="TDec_0302_04RTC">
 							<xs:annotation>
-								<xs:documentation>Aliquota da CBS</xs:documentation>
+								<xs:documentation>Aliquota da CBS (em percentual)</xs:documentation>
 							</xs:annotation>
 						</xs:element>
 						<xs:element name="gDif" type="TDif" minOccurs="0">
@@ -808,7 +949,7 @@
 								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="vCBS" type="TDec1302">
+						<xs:element name="vCBS" type="TDec1302RTC">
 							<xs:annotation>
 								<xs:documentation>Valor da CBS</xs:documentation>
 							</xs:annotation>
@@ -819,16 +960,6 @@
 			<xs:element name="gTribRegular" type="TTribRegular" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Grupo de informações da Tributação Regular. Informar como seria a tributação caso não cumprida a condição resolutória/suspensiva. Exemplo 1: Art. 442, §4. Operações com ZFM e ALC. Exemplo 2: Operações com suspensão do tributo.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="gIBSCredPres" type="TCredPres" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Grupo de Informações do Crédito Presumido referente ao IBS, quando aproveitado pelo emitente do documento. </xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="gCBSCredPres" type="TCredPres" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Grupo de Informações do Crédito Presumido referente a CBS, quando aproveitado pelo emitente do documento. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="gTribCompraGov" type="TTribCompraGov" minOccurs="0">
@@ -843,14 +974,14 @@
 			<xs:documentation>Tipo Redução Base de Cálculo</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="pRedAliq" type="TDec_0302_04">
+			<xs:element name="pRedAliq" type="TDec_0302_04RTC">
 				<xs:annotation>
 					<xs:documentation>Percentual de redução de aliquota do cClassTrib</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pAliqEfet" type="TDec_0302_04">
+			<xs:element name="pAliqEfet" type="TDec_0302_04RTC">
 				<xs:annotation>
-					<xs:documentation>Aliquota Efetiva que será aplicada a Base de Calculo</xs:documentation>
+					<xs:documentation>Aliquota Efetiva que será aplicada a Base de Calculo (em percentual)</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -860,23 +991,18 @@
 			<xs:documentation>Tipo Crédito Presumido</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="cCredPres">
-				<xs:annotation>
-					<xs:documentation>Usar tabela Cred Presumido, para o emitente da nota.</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-			<xs:element name="pCredPres" type="TDec_0302_04">
+			<xs:element name="pCredPres" type="TDec_0302_04RTC">
 				<xs:annotation>
 					<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:choice>
-				<xs:element name="vCredPres" type="TDec1302">
+				<xs:element name="vCredPres" type="TDec1302RTC">
 					<xs:annotation>
 						<xs:documentation>Valor do Crédito Presumido</xs:documentation>
 					</xs:annotation>
 				</xs:element>
-				<xs:element name="vCredPresCondSus" type="TDec1302">
+				<xs:element name="vCredPresCondSus" type="TDec1302RTC">
 					<xs:annotation>
 						<xs:documentation>Valor do Crédito Presumido Condição Suspensiva, preencher apenas para cCredPres que possui indicação de Condição Suspensiva</xs:documentation>
 					</xs:annotation>
@@ -889,12 +1015,12 @@
 			<xs:documentation>Tipo Diferimento</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="pDif" type="TDec_0302_04">
+			<xs:element name="pDif" type="TDec_0302_04RTC">
 				<xs:annotation>
 					<xs:documentation>Percentual do diferimento</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vDif" type="TDec1302">
+			<xs:element name="vDif" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do diferimento</xs:documentation>
 				</xs:annotation>
@@ -906,7 +1032,7 @@
 			<xs:documentation>Tipo Devolução Tributo</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="vDevTrib" type="TDec1302">
+			<xs:element name="vDevTrib" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do tributo devolvido. No fornecimento de energia elétrica, água, esgoto e
 gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
@@ -930,37 +1056,37 @@ gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
 					<xs:documentation>Informar qual seria o cClassTrib caso não cumprida a condição resolutória/suspensiva</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pAliqEfetRegIBSUF" type="TDec_0302_04">
+			<xs:element name="pAliqEfetRegIBSUF" type="TDec_0302_04RTC">
 				<xs:annotation>
 					<xs:documentation>Alíquota do IBS da UF</xs:documentation>
 					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vTribRegIBSUF" type="TDec1302">
+			<xs:element name="vTribRegIBSUF" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do IBS da UF</xs:documentation>
 					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pAliqEfetRegIBSMun" type="TDec_0302_04">
+			<xs:element name="pAliqEfetRegIBSMun" type="TDec_0302_04RTC">
 				<xs:annotation>
 					<xs:documentation>Alíquota do IBS do Município</xs:documentation>
 					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vTribRegIBSMun" type="TDec1302">
+			<xs:element name="vTribRegIBSMun" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do IBS do Município</xs:documentation>
 					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pAliqEfetRegCBS" type="TDec_0302_04">
+			<xs:element name="pAliqEfetRegCBS" type="TDec_0302_04RTC">
 				<xs:annotation>
 					<xs:documentation>Alíquota da CBS</xs:documentation>
 					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vTribRegCBS" type="TDec1302">
+			<xs:element name="vTribRegCBS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor da CBS</xs:documentation>
 					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
@@ -973,20 +1099,20 @@ gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
 			<xs:documentation>Tipo Tributação Compra Governamental</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="pAliqIBSUF" type="TDec_0302_04"/>
-			<xs:element name="vTribIBSUF" type="TDec1302">
+			<xs:element name="pAliqIBSUF" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribIBSUF" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor que seria devido a UF, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pAliqIBSMun" type="TDec_0302_04"/>
-			<xs:element name="vTribIBSMun" type="TDec1302">
+			<xs:element name="pAliqIBSMun" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribIBSMun" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor que seria devido ao município, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pAliqCBS" type="TDec_0302_04"/>
-			<xs:element name="vTribCBS" type="TDec1302">
+			<xs:element name="pAliqCBS" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribCBS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor que seria devido a CBS, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
 				</xs:annotation>
@@ -1008,9 +1134,9 @@ gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
 4=Municípios</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pRedutor" type="TDec_0302_04">
+			<xs:element name="pRedutor" type="TDec_0302_04RTC">
 				<xs:annotation>
-					<xs:documentation>Percentual de redução de aliquota em compra goverrnamental</xs:documentation>
+					<xs:documentation>Percentual de redução de aliquota em compra governamental</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -1030,9 +1156,9 @@ gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
 4=Municípios</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="pRedutor" type="TDec_0302_04">
+			<xs:element name="pRedutor" type="TDec_0302_04RTC">
 				<xs:annotation>
-					<xs:documentation>Percentual de redução de aliquota em compra goverrnamental</xs:documentation>
+					<xs:documentation>Percentual de redução de aliquota em compra governamental</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="tpOperGov" type="TOperCompraGov">
@@ -1049,14 +1175,88 @@ gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
 			<xs:documentation>Tipo Transferência de Crédito</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="vIBS" type="TDec1302">
+			<xs:element name="vIBS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do IBS a ser transferido</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vCBS" type="TDec1302">
+			<xs:element name="vCBS" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor da CBS a ser transferida</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEstornoCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Estorno de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBSEstCred" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser estornado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBSEstCred" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser estornada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TCompetApur">
+		<xs:annotation>
+			<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:gYearMonth">
+			<xs:minInclusive value="2025-01"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TAjusteCompet">
+		<xs:annotation>
+			<xs:documentation>Tipo Ajuste de Competência</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="competApur" type="TCompetApur">
+				<xs:annotation>
+					<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vIBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresOper">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido da Operação</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCCredPres" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da Base de Cálculo do Crédito Presumido da Operação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cCredPres" type="TcCredPres">
+				<xs:annotation>
+					<xs:documentation>Código de Classificação do Crédito Presumido do IBS e da CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente ao IBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gCBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente a CBS, quando aproveitado pelo emitente do documento. </xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
@@ -1066,6 +1266,11 @@ gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
 			<xs:documentation>Tipo Informações do crédito presumido de IBS para fornecimentos a partir da ZFM</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
+			<xs:element name="competApur" type="TCompetApur">
+				<xs:annotation>
+					<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
 			<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM">
 				<xs:annotation>
 					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
@@ -1078,7 +1283,7 @@ OBS: Percentuais definidos no art. 450, § 1º, da LC 214/25 para o cálculo do 
 </xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="vCredPresIBSZFM" type="TDec1302" minOccurs="0">
+			<xs:element name="vCredPresIBSZFM" type="TDec1302RTC">
 				<xs:annotation>
 					<xs:documentation>Valor do crédito presumido calculado sobre o saldo devedor apurado</xs:documentation>
 				</xs:annotation>

--- a/NFe.AppTeste/Schemas/leiauteConsSitNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteConsSitNFe_v4.00.xsd
@@ -4,7 +4,6 @@
 <!--  PL_006eventos versao alterada para consultar eventos 30/08/2010 -->
 <!--  PL_006f versao com correcoes no xServ para tornar a literal CONSULTAR obrigatoria 21/05/2010 -->
 <!--  PL_006c versao com correcoes 24/12/2009 -->
-<!--  PL_009  versão 4.00 NT2018.005 v1.00-->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
 	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
@@ -316,7 +315,7 @@
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="ID[0-9]{52}"/>
+								<xs:pattern value="ID[0-9]{12}[0-9A-Z]{12}[0-9]{28}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>

--- a/NFe.AppTeste/Schemas/leiauteInutNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteInutNFe_v4.00.xsd
@@ -76,7 +76,7 @@
 					<xs:attribute name="Id" use="required">
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="ID[0-9]{41}"/>
+								<xs:pattern value="ID[0-9]{4}[0-9A-Z]{12}[0-9]{25}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>

--- a/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/leiauteNFe_v4.00.xsd
@@ -94,6 +94,11 @@ SCAN 900-999</xs:documentation>
 											<xs:documentation>Data e Hora da saída ou de entrada da mercadoria / produto (AAAA-MM-DDTHH:mm:ssTZD)</xs:documentation>
 										</xs:annotation>
 									</xs:element>
+									<xs:element name="dPrevEntrega" type="TData" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data da previsão de entrega ou disponibilização do bem (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
 									<xs:element name="tpNF">
 										<xs:annotation>
 											<xs:documentation>Tipo do Documento Fiscal (0 - entrada; 1 - saída)</xs:documentation>
@@ -269,7 +274,8 @@ Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do e
 1 - emissão de NF-e avulsa pelo Fisco;
 2 - emissão de NF-e avulsa, pelo contribuinte com seu certificado digital, através do site
 do Fisco;
-3- emissão de NF-e pelo contribuinte com aplicativo fornecido pelo Fisco.</xs:documentation>
+3 - emissão de NF-e pelo contribuinte com aplicativo fornecido pelo Fisco;
+4 - emissão de NF-e por Provedor de Assinatura e Autorização - PAA.</xs:documentation>
 										</xs:annotation>
 									</xs:element>
 									<xs:element name="verProc">
@@ -502,7 +508,7 @@ Preencher com &quot;2B&quot;, quando se tratar de Cupom Fiscal emitido por máqu
 										</xs:annotation>
 										<xs:complexType>
 											<xs:sequence>
-												<xs:element name="refNFe" type="TChNFe" minOccurs="1" maxOccurs="99">
+												<xs:element name="refNFe" type="TChNFe" maxOccurs="99">
 													<xs:annotation>
 														<xs:documentation>Chave de acesso da NF-e de antecipação de pagamento</xs:documentation>
 													</xs:annotation>
@@ -992,6 +998,11 @@ Formato ”CFOP9999”.</xs:documentation>
 															</xs:element>
 														</xs:sequence>
 													</xs:complexType>
+												</xs:element>
+												<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Classificação para subapuração do IBS na ZFM</xs:documentation>
+													</xs:annotation>
 												</xs:element>
 												<xs:element name="EXTIPI" minOccurs="0">
 													<xs:annotation>
@@ -2551,13 +2562,15 @@ ambiente.</xs:documentation>
 																					</xs:element>
 																					<xs:element name="motDesICMS">
 																						<xs:annotation>
-																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros; 10=Deficiente Condutor (Convênio ICMS 38/12); 11=Deficiente Não Condutor (Convênio ICMS 38/12);  12-Fomento agropecuário</xs:documentation>
 																						</xs:annotation>
 																						<xs:simpleType>
 																							<xs:restriction base="xs:string">
 																								<xs:whiteSpace value="preserve"/>
 																								<xs:enumeration value="3"/>
 																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
 																								<xs:enumeration value="12"/>
 																							</xs:restriction>
 																						</xs:simpleType>
@@ -3391,11 +3404,39 @@ Informar o motivo da desoneração:
 																							<xs:documentation>Percentual de redução da BC</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
+																					<xs:element name="cBenefRBC" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
 																					<xs:element name="pICMS" type="TDec_0302a04">
 																						<xs:annotation>
 																							<xs:documentation>Alíquota do ICMS</xs:documentation>
 																						</xs:annotation>
 																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vICMSOp" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS da Operação</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pDif" type="TDec_0302a04Max100">
+																							<xs:annotation>
+																								<xs:documentation>Percentual do diferemento</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vICMSDif" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS da diferido</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
 																					<xs:element name="vICMS" type="TDec_1302">
 																						<xs:annotation>
 																							<xs:documentation>Valor do ICMS</xs:documentation>
@@ -3415,6 +3456,23 @@ Informar o motivo da desoneração:
 																						<xs:element name="vFCP" type="TDec_1302">
 																							<xs:annotation>
 																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="pFCPDif" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPDif" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPEfet" type="TDec_1302" minOccurs="0">
+																							<xs:annotation>
+																								<xs:documentation>Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
 																							</xs:annotation>
 																						</xs:element>
 																					</xs:sequence>
@@ -3565,12 +3623,14 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																					<xs:annotation>
 																						<xs:documentation>Tributação pelo ICMS 
 10 - Tributada e com cobrança do ICMS por substituição tributária;
+20 – Redução de base de cálculo
 90 – Outros.</xs:documentation>
 																					</xs:annotation>
 																					<xs:simpleType>
 																						<xs:restriction base="xs:string">
 																							<xs:whiteSpace value="preserve"/>
 																							<xs:enumeration value="10"/>
+																							<xs:enumeration value="20"/>
 																							<xs:enumeration value="90"/>
 																						</xs:restriction>
 																					</xs:simpleType>
@@ -3689,6 +3749,43 @@ Operação interestadual para consumidor final com partilha do ICMS  devido na o
 																						<xs:documentation>Sigla da UF para qual é devido o ICMS ST da operação.</xs:documentation>
 																					</xs:annotation>
 																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:9-Outros;10=Deficiente Condutor (Convênio ICMS 38/12) 11=Deficiente Não Condutor (Convênio ICMS 38/12)</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
 																			</xs:sequence>
 																		</xs:complexType>
 																	</xs:element>
@@ -6477,6 +6574,40 @@ tipo de ato concessório:
 								</xs:choice>
 							</xs:complexType>
 						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
 					</xs:sequence>
 					<xs:attribute name="versao" type="TVerNFe" use="required">
 						<xs:annotation>
@@ -6489,7 +6620,7 @@ tipo de ato concessório:
 						</xs:annotation>
 						<xs:simpleType>
 							<xs:restriction base="xs:ID">
-								<xs:pattern value="NFe[0-9]{44}"/>
+								<xs:pattern value="NFe[0-9]{6}[0-9A-Z]{12}[0-9]{26}"/>
 							</xs:restriction>
 						</xs:simpleType>
 					</xs:attribute>
@@ -6515,15 +6646,15 @@ tipo de ato concessório:
 									<xs:minLength value="60"/>
 									<xs:maxLength value="1000"/>
 									<!--QRCODE V1-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{6}[0-9A-Z]{12}[0-9]{26}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
 									<!--QRCODE V2 ONLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
 									<!--QRCODE V2 OFFLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
 									<!--QRCODE V3 ONLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
 									<!--QRCODE V3 OFFLINE-->
-									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{6}[0-9A-Z]{12}[0-9]{16}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
 								</xs:restriction>
 							</xs:simpleType>
 						</xs:element>
@@ -7345,7 +7476,15 @@ alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
 	</xs:simpleType>
 	<xs:simpleType name="TTpNFDebito">
 		<xs:annotation>
-			<xs:documentation>Tipo de Nota de Débito: 01=Transferência de créditos para Cooperativas; 02=Anulação de Crédito por Saídas Imunes/Isentas; 03=Débitos de notas fiscais não processadas na apuração; 04=Multa e juros; 05=Transferência de crédito de sucessão); 06=Pagamento antecipado; 07=Perda em estoque</xs:documentation>
+			<xs:documentation>Tipo de Nota de Débito: 
+			01=Transferência de créditos para Cooperativas; 
+			02=Anulação de Crédito por Saídas Imunes/Isentas; 
+			03=Débitos de notas fiscais não processadas na apuração; 
+			04=Multa e juros; 
+			05=Transferência de crédito na sucessão; 
+			06=Pagamento antecipado; 
+			07=Perda em estoque; 
+			08=Desenquadramento do SN;</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
@@ -7356,16 +7495,26 @@ alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
 			<xs:enumeration value="05"/>
 			<xs:enumeration value="06"/>
 			<xs:enumeration value="07"/>
+			<xs:enumeration value="08"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TTpNFCredito">
 		<xs:annotation>
-			<xs:documentation>Tipo de Nota de Crédito: 01=Multa e juros; 02=Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)</xs:documentation>
+			<xs:documentation>Tipo de Nota de Crédito: 
+			01=Multa e juros; 
+			02=Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25);
+			03=Retorno por recusa na entrega ou por não localização do destinatário na tentativa de entrega;
+			04=Redução de valores;
+			05=Transferência de crédito na sucessão;
+			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:enumeration value="01"/>
 			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TProcEmi">
@@ -7378,6 +7527,7 @@ alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
 			<xs:enumeration value="1"/>
 			<xs:enumeration value="2"/>
 			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCListServ">

--- a/NFe.AppTeste/Schemas/nfe_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/nfe_v4.00.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
 <xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
 	<xs:element name="NFe" type="TNFe">

--- a/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
+++ b/NFe.AppTeste/Schemas/tiposBasico_v4.00.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
 <!-- PL_008  - 30/07/2013- NT 2013/005 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nfe="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="TCodUfIBGE">
@@ -52,7 +53,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="44"/>
-			<xs:pattern value="[0-9]{44}"/>
+			<xs:pattern value="[0-9]{6}[0-9A-Z]{12}[0-9]{26}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TProt">
@@ -92,7 +93,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{14}"/>
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjVar">
@@ -102,7 +103,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{3,14}"/>
+			<xs:pattern value="[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCnpjOpc">
@@ -112,7 +113,7 @@
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
 			<xs:maxLength value="14"/>
-			<xs:pattern value="[0-9]{0}|[0-9]{14}"/>
+			<xs:pattern value="[0-9]{0}|[0-9A-Z]{12}[0-9]{2}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TCpf">
@@ -521,7 +522,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TData">
@@ -595,4 +596,13 @@
 			<xs:enumeration value="92"/>
 		</xs:restriction>
 	</xs:simpleType>
+	<xs:complexType name="TRSAKeyValueType">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa uma chave publica padrão RSA</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Modulus" type="xs:base64Binary"/>
+			<xs:element name="Exponent" type="xs:base64Binary"/>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/NFe.Classes/Informacoes/Destinatario/dest.cs
+++ b/NFe.Classes/Informacoes/Destinatario/dest.cs
@@ -1,15 +1,15 @@
+using DFe.Classes.Flags;
 using System;
 using System.Xml.Serialization;
-using DFe.Classes.Flags;
-using NFe.Classes.Servicos.Tipos;
 
 namespace NFe.Classes.Informacoes.Destinatario
 {
     public class dest
     {
-        private const string ErroCpfCnpjPreenchidos = "Somente preencher um dos campos: CNPJ ou CPF, para um objeto do tipo dest!";
+        private const string ErroCpfCnpjIdEstrangeiroPreenchidos = "Somente preencher um dos campos: CNPJ, CPF ou idEstrangeiro, para um objeto do tipo dest!";
         private string cnpj;
         private string cpf;
+        private string _idEstrangeiro;
         private readonly VersaoServico _versao;
 
         /// <summary>
@@ -34,13 +34,12 @@ namespace NFe.Classes.Informacoes.Destinatario
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
-                    throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(cpf) || !string.IsNullOrEmpty(idEstrangeiro))
+                    throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
+                
+                cnpj = value;
             }
         }
 
@@ -52,20 +51,31 @@ namespace NFe.Classes.Informacoes.Destinatario
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
-                    throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(cnpj) || !string.IsNullOrEmpty(idEstrangeiro))
+                    throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
+
+                cpf = value;
             }
         }
 
         /// <summary>
         ///     E03a - Identificador do destinatário, em caso de comprador estrangeiro
         /// </summary>
-        public string idEstrangeiro { get; set; }
+        public string idEstrangeiro
+        {
+            get { return _idEstrangeiro; }
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(CPF))
+                    throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
+
+                _idEstrangeiro = value;
+            }
+        }
 
         /// <summary>
         ///     E04 - Razão Social ou nome do destinatário

--- a/NFe.Classes/Informacoes/Emitente/emit.cs
+++ b/NFe.Classes/Informacoes/Emitente/emit.cs
@@ -17,14 +17,12 @@ namespace NFe.Classes.Informacoes.Emitente
             get { return _cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(_cpf))
-                    _cnpj = Regex.Match(value, @"\d+").Value;
-
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(_cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                _cnpj = value;
             }
         }
 
@@ -36,13 +34,12 @@ namespace NFe.Classes.Informacoes.Emitente
             get { return _cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(_cnpj))
-                    _cpf = Regex.Match(value, @"\d+").Value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(_cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                _cpf = value;
             }
         }
 

--- a/NFe.Classes/Informacoes/Transporte/transporta.cs
+++ b/NFe.Classes/Informacoes/Transporte/transporta.cs
@@ -16,13 +16,12 @@ namespace NFe.Classes.Informacoes.Transporte
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+                
+                cnpj = value;
             }
         }
 
@@ -34,13 +33,12 @@ namespace NFe.Classes.Informacoes.Transporte
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cpf = value;
             }
         }
 

--- a/NFe.Classes/Informacoes/autXML.cs
+++ b/NFe.Classes/Informacoes/autXML.cs
@@ -16,13 +16,12 @@ namespace NFe.Classes.Informacoes
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cnpj = value;
             }
         }
 
@@ -34,13 +33,12 @@ namespace NFe.Classes.Informacoes
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+    
+                cpf = value;
             }
         }
     }

--- a/NFe.Classes/Informacoes/entrega.cs
+++ b/NFe.Classes/Informacoes/entrega.cs
@@ -17,13 +17,12 @@ namespace NFe.Classes.Informacoes
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cnpj = value;
             }
         }
 
@@ -35,13 +34,12 @@ namespace NFe.Classes.Informacoes
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cpf = value;
             }
         }
 

--- a/NFe.Classes/Informacoes/retirada.cs
+++ b/NFe.Classes/Informacoes/retirada.cs
@@ -17,13 +17,12 @@ namespace NFe.Classes.Informacoes
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cnpj = value;
             }
         }
 
@@ -35,13 +34,12 @@ namespace NFe.Classes.Informacoes
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cpf = value;
             }
         }
 

--- a/NFe.Classes/Servicos/ConsultaCadastro/infConsEnv.cs
+++ b/NFe.Classes/Servicos/ConsultaCadastro/infConsEnv.cs
@@ -33,13 +33,12 @@ namespace NFe.Classes.Servicos.ConsultaCadastro
             get { return _ie; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CNPJ) & string.IsNullOrEmpty(CPF))
-                    _ie = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(CPF))
                     throw new ArgumentException(ErroCpfCnpjIePreenchidos);
-                }
+                
+                _ie = value;
             }
         }
 
@@ -52,13 +51,12 @@ namespace NFe.Classes.Servicos.ConsultaCadastro
             get { return _cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CPF) & string.IsNullOrEmpty(IE))
-                    _cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(CPF) || !string.IsNullOrEmpty(IE))
                     throw new ArgumentException(ErroCpfCnpjIePreenchidos);
-                }
+
+                _cnpj = value;
             }
         }
 
@@ -71,13 +69,12 @@ namespace NFe.Classes.Servicos.ConsultaCadastro
             get { return _cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CNPJ) & string.IsNullOrEmpty(IE))
-                    _cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(IE))
                     throw new ArgumentException(ErroCpfCnpjIePreenchidos);
-                }
+
+                _cpf = value;
             }
         }
     }

--- a/NFe.Classes/Servicos/DistribuicaoDFe/distDFeInt.cs
+++ b/NFe.Classes/Servicos/DistribuicaoDFe/distDFeInt.cs
@@ -38,13 +38,12 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe
             get { return _cNPJ; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(_cPF))
-                    _cNPJ = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(_cPF))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                _cNPJ = value;
             }
         }
 
@@ -56,13 +55,12 @@ namespace NFe.Classes.Servicos.DistribuicaoDFe
             get { return _cPF; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(_cNPJ))
-                    _cPF = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(_cNPJ))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                _cPF = value;
             }
         }
 

--- a/NFe.Classes/Servicos/Evento/dest.cs
+++ b/NFe.Classes/Servicos/Evento/dest.cs
@@ -26,13 +26,12 @@ namespace NFe.Classes.Servicos.Evento
             get { return _cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CPF) & string.IsNullOrEmpty(idEstrangeiro))
-                    _cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(CPF) || !string.IsNullOrEmpty(idEstrangeiro))
                     throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
-                }
+
+                _cnpj = value;
             }
         }
 
@@ -44,13 +43,12 @@ namespace NFe.Classes.Servicos.Evento
             get { return _cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CNPJ) & string.IsNullOrEmpty(idEstrangeiro))
-                    _cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(idEstrangeiro))
                     throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
-                }
+
+                _cpf = value;
             }
         }
 
@@ -63,12 +61,10 @@ namespace NFe.Classes.Servicos.Evento
             set
             {
                 if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(CNPJ) & string.IsNullOrEmpty(CPF))
-                    _idEstrangeiro = value;
-                else
-                {
+                if (!string.IsNullOrEmpty(CNPJ) || !string.IsNullOrEmpty(CPF))
                     throw new ArgumentException(ErroCpfCnpjIdEstrangeiroPreenchidos);
-                }
+
+                _idEstrangeiro = value;
             }
         }
 

--- a/NFe.Classes/Servicos/Evento/infEventoEnv.cs
+++ b/NFe.Classes/Servicos/Evento/infEventoEnv.cs
@@ -37,13 +37,12 @@ namespace NFe.Classes.Servicos.Evento
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cnpj = value;
             }
         }
 
@@ -55,13 +54,12 @@ namespace NFe.Classes.Servicos.Evento
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cpf = value;
             }
         }
 

--- a/NFe.Classes/Servicos/Evento/infEventoRet.cs
+++ b/NFe.Classes/Servicos/Evento/infEventoRet.cs
@@ -78,13 +78,12 @@ namespace NFe.Classes.Servicos.Evento
             get { return cnpj; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cpf))
-                    cnpj = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value)) 
+                    return;
+                if (!string.IsNullOrEmpty(cpf))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cnpj = value;
             }
         }
 
@@ -96,13 +95,12 @@ namespace NFe.Classes.Servicos.Evento
             get { return cpf; }
             set
             {
-                if (string.IsNullOrEmpty(value)) return;
-                if (string.IsNullOrEmpty(cnpj))
-                    cpf = value;
-                else
-                {
+                if (string.IsNullOrEmpty(value))
+                    return;
+                if (!string.IsNullOrEmpty(cnpj))
                     throw new ArgumentException(ErroCpfCnpjPreenchidos);
-                }
+
+                cpf = value;
             }
         }
 


### PR DESCRIPTION
Adicionado Schemas para Validação de CNPJ Alfanumérico, retirado validação numérica de propriedades CNPJ
- Realizado teste com SUCESSO de Emissão da NFe para Destinatário com CNPJ Alfanumérico
- Proximo passo a ser implementado é o Emitente com CNPJ Alfanumérico