### PR TITLE
fix/chave-fiscal-cnpj-alfanumerico

### DIFF
--- a/DFe.Utils/ChaveFiscal.cs
+++ b/DFe.Utils/ChaveFiscal.cs
@@ -26,14 +26,17 @@ namespace DFe.Utils
         {
             var chave = new StringBuilder();
 
+            if (cnpjEmitente.Length < 14)
+                cnpjEmitente = cnpjEmitente.PadLeft(14, '0');
+
             chave.Append(((int)ufEmitente).ToString("D2"))
-                .Append(dataEmissao.ToString("yyMM"))
-                .Append(cnpjEmitente)
-                .Append(((int)modelo).ToString("D2"))
-                .Append(serie.ToString("D3"))
-                .Append(numero.ToString("D9"))
-                .Append(tipoEmissao.ToString())
-                .Append(cNf.ToString("D8"));
+                 .Append(dataEmissao.ToString("yyMM"))
+                 .Append(cnpjEmitente)
+                 .Append(((int)modelo).ToString("D2"))
+                 .Append(serie.ToString("D3"))
+                 .Append(numero.ToString("D9"))
+                 .Append(tipoEmissao.ToString())
+                 .Append(cNf.ToString("D8"));
 
             var digitoVerificador = ObterDigitoVerificador(chave.ToString());
 
@@ -57,8 +60,8 @@ namespace DFe.Utils
             //percorrendo cada caractere da chave da direita para esquerda para fazer os cálculos com o peso
             for (var i = chave.Length - 1; i != -1; i--)
             {
-                var ch = Convert.ToInt32(chave[i].ToString());
-                soma += ch*peso;
+                var valorCaractere = ObterValorDoCaractere(chave[i]);
+                soma += valorCaractere * peso;
                 //sempre que for 9 voltamos o peso a 2
                 if (peso < 9)
                     peso += 1;
@@ -67,7 +70,7 @@ namespace DFe.Utils
             }
 
             //Agora que tenho a soma vamos pegar o resto da divisão por 11
-            mod = soma%11;
+            mod = soma % 11;
             //Aqui temos uma regrinha, se o resto da divisão for 0 ou 1 então o dv vai ser 0
             if (mod == 0 || mod == 1)
                 dv = 0;
@@ -75,6 +78,18 @@ namespace DFe.Utils
                 dv = 11 - mod;
 
             return dv.ToString();
+        }
+
+        /// <summary>
+        /// Obtem o valor de um caractere
+        /// </summary>
+        /// <param name="caractere"></param>
+        /// <returns></returns>
+        internal static int ObterValorDoCaractere(char caractere)
+        {
+            const int zeroASCII = 48;
+            var valor = caractere - zeroASCII;
+            return valor;
         }
 
         /// <summary>


### PR DESCRIPTION
fix/chave-fiscal-cnpj-alfanumerico
 
Ajusta chave fiscal para CNPJ alfanumérico
 
Contexto: A geração da chave fiscal apresentava erro quando o CNPJ do emitente continha caracteres alfanuméricos, pois o cálculo do dígito verificador tentava converter cada caractere da chave diretamente para inteiro.
Ajustado o cálculo do dígito verificador para utilizar o valor do caractere, seguindo a implementação já existente no projeto Zeus.
Também foi incluído o preenchimento à esquerda do CNPJ do emitente quando ele possuir menos de 14 posições.
Esperado:

- Permitir a geração da chave fiscal com CNPJ alfanumérico no emitente;
- Manter o comportamento atual para CNPJs exclusivamente numéricos.