### PR TITLE
fix(mdfe): MDFeInfEvento aceita MDFeConfiguracao via construtor

### DIFF
--- a/MDFe.Classes/Informacoes/Evento/MDFeInfEvento.cs
+++ b/MDFe.Classes/Informacoes/Evento/MDFeInfEvento.cs
@@ -14,7 +14,15 @@ namespace MDFe.Classes.Informacoes.Evento
     public class MDFeInfEvento
     {
         [XmlIgnore]
-        private readonly VersaoServico _versaoServico = MDFeConfiguracao.Instancia.VersaoWebService.VersaoLayout;
+        private readonly VersaoServico _versaoServico;
+
+        public MDFeInfEvento() : this(null) { }
+
+        public MDFeInfEvento(MDFeConfiguracao cfgMdfe)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            _versaoServico = config.VersaoWebService.VersaoLayout;
+        }
 
         [XmlAttribute(AttributeName = "Id")]
         public string Id { get; set; }

--- a/MDFe.Servicos/EventosMDFe/FactoryEvento.cs
+++ b/MDFe.Servicos/EventosMDFe/FactoryEvento.cs
@@ -15,7 +15,7 @@ namespace MDFe.Servicos.EventosMDFe
             var eventoMDFe = new MDFeEventoMDFe
             {
                 Versao = config.VersaoWebService.VersaoLayout,
-                InfEvento = new MDFeInfEvento
+                InfEvento = new MDFeInfEvento(config)
                 {
                     Id = "ID" + (long)tipoEvento + MDFe.Chave() + sequenciaEvento.ToString("D2"),
                     TpAmb = config.VersaoWebService.TipoAmbiente,


### PR DESCRIPTION
Resolve uso incorreto em ambientes multi-tenant / DI. 

A classe capturava VersaoServico lendo do singleton "MDFeConfiguracao.Instancia" no construtor, 
ignorando o cfgMdfe passado pelo caller. 

Em sistemas com Dependency Injection (Scoped), o singleton nao e configurado por
design, e a primeira chamada a ServicoMDFeEvento quebrava com "Versao invalida do mdf-e".

Obs: construtor sem args continua delegando para MDFeConfiguracao.Instancia.