### PR TITLE
NFe: corrige endereçamento e schema do evento 112130

### DIFF
--- a/NFe.Servicos/ServicoNfeFactory.cs
+++ b/NFe.Servicos/ServicoNfeFactory.cs
@@ -238,7 +238,7 @@ namespace NFe.Servicos
                     return new RecepcaoEvento4AN(url, certificado, cfg.TimeOut);
 
                 case ServicoNFe.RecepcaoEventoPerecimentoTransporteNFe:
-                    return new RecepcaoEvento4AN(url, certificado, cfg.TimeOut);
+                    return new RecepcaoEvento4SVCAN(url, certificado, cfg.TimeOut);
 
                 case ServicoNFe.RecepcaoEventoConciliacaoFinanceiraNFe:
                 case ServicoNFe.RecepcaoEventoCancConciliacaoFinanceiraNFe:

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -1127,7 +1127,7 @@ namespace NFe.Servicos
 
             var infEvento = new infEventoEnv
             {
-                cOrgao = Estado.AN,
+                cOrgao = Estado.SVRS,
                 tpAmb = _cFgServico.tpAmb,
                 chNFe = chaveNFe,
                 dhEvento = dhEvento ?? DateTime.Now,

--- a/NFe.Utils/Enderecos/Enderecador.cs
+++ b/NFe.Utils/Enderecos/Enderecador.cs
@@ -1590,7 +1590,7 @@ namespace NFe.Utils.Enderecos
                         addServico(new[] { ServicoNFe.NfeDownloadNF }, versao2E3, prod, TipoEmissao.teNormal, estado, modelo, "https://www.nfe.fazenda.gov.br/NfeDownloadNF/NfeDownloadNF.asmx");
                     if (modelo != ModeloDocumento.NFCe)
                     {
-                        addServico(new[] { ServicoNFe.NFeDistribuicaoDFe }, versao1, prod, TipoEmissao.teNormal, estado, modelo, "https://www.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx");
+                        addServico(new[] { ServicoNFe.NFeDistribuicaoDFe }, versao1, prod, TipoEmissao.teNormal, estado, modelo, "https://www1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx");
 
                         // Perecimento, perda, roubo ou furto durante o transporte
                         addServico(eventoPerecimentoTransporteNFe, versao1, prod, TipoEmissao.teNormal, estado, modelo, "https://www.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx");

--- a/NFe.Utils/Enderecos/Enderecador.cs
+++ b/NFe.Utils/Enderecos/Enderecador.cs
@@ -1557,9 +1557,6 @@ namespace NFe.Utils.Enderecos
                     if (modelo != ModeloDocumento.NFCe)
                     {
                         addServico(new[] { ServicoNFe.NFeDistribuicaoDFe }, versao1, hom, TipoEmissao.teNormal, estado, modelo, "https://hom1.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx");
-
-                        // Perecimento, perda, roubo ou furto durante o transporte
-                        addServico(eventoPerecimentoTransporteNFe, versao1, hom, TipoEmissao.teNormal, estado, modelo, "https://hom1.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx");
                     }
 
                     // Comprovante de Entrega
@@ -1594,9 +1591,6 @@ namespace NFe.Utils.Enderecos
                     if (modelo != ModeloDocumento.NFCe)
                     {
                         addServico(new[] { ServicoNFe.NFeDistribuicaoDFe }, versao1, prod, TipoEmissao.teNormal, estado, modelo, "https://www.nfe.fazenda.gov.br/NFeDistribuicaoDFe/NFeDistribuicaoDFe.asmx");
-
-                        // Perecimento, perda, roubo ou furto durante o transporte
-                        addServico(eventoPerecimentoTransporteNFe, versao1, prod, TipoEmissao.teNormal, estado, modelo, "https://www.nfe.fazenda.gov.br/NFeRecepcaoEvento4/NFeRecepcaoEvento4.asmx");
                     }
 
                     // Comprovante de Entrega
@@ -1631,6 +1625,10 @@ namespace NFe.Utils.Enderecos
                             //Conciliação Financeira NFe
                             addServico(new[] { ServicoNFe.RecepcaoEventoConciliacaoFinanceiraNFe, ServicoNFe.RecepcaoEventoCancConciliacaoFinanceiraNFe }, versao1, TipoAmbiente.Producao, emissao, estado, modelo, "https://nfe.svrs.rs.gov.br/ws/recepcaoevento/recepcaoevento4.asmx");
                             addServico(new[] { ServicoNFe.RecepcaoEventoConciliacaoFinanceiraNFe, ServicoNFe.RecepcaoEventoCancConciliacaoFinanceiraNFe }, versao1, TipoAmbiente.Homologacao, emissao, estado, modelo, "https://nfe-homologacao.svrs.rs.gov.br/ws/recepcaoevento/recepcaoevento4.asmx");
+
+                            //Perecimento, perda, roubo ou furto durante o transporte
+                            addServico(eventoPerecimentoTransporteNFe, versao1, TipoAmbiente.Producao, emissao, estado, modelo, "https://nfe.svrs.rs.gov.br/ws/recepcaoevento/recepcaoevento4.asmx");
+                            addServico(eventoPerecimentoTransporteNFe, versao1, TipoAmbiente.Homologacao, emissao, estado, modelo, "https://nfe-homologacao.svrs.rs.gov.br/ws/recepcaoevento/recepcaoevento4.asmx");
                         }
                     }
                 }

--- a/NFe.Utils/Validacao/Validador.cs
+++ b/NFe.Utils/Validacao/Validador.cs
@@ -43,7 +43,7 @@ namespace NFe.Utils.Validacao
                 case ServicoNFe.RecepcaoEventoCancConciliacaoFinanceiraNFe:
                     return "envEventoCancEConf_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoPerecimentoTransporteNFe:
-                    return "envEvento_v1.00.xsd";
+                    return "envEventoNFe_v9.99.xsd";
                 case ServicoNFe.RecepcaoEventoEpec:
                     return "envEPEC_v1.00.xsd";
                 case ServicoNFe.RecepcaoEventoManifestacaoDestinatario:


### PR DESCRIPTION
O evento de perecimento, perda, roubo ou furto durante o transporte passa a ser enviado ao webservice do SVRS em vez do Ambiente Nacional, com ajuste do schema de validação para envEventoNFe_v9.99.xsd.