### PR TITLE
feat(MDFe): adiciona sobrecargas para emissão de eventos sem necessidade do MDFeEletronico completo

### DIFF
--- a/MDFe.Servicos/EventosMDFe/Contratos/IServicoController.cs
+++ b/MDFe.Servicos/EventosMDFe/Contratos/IServicoController.cs
@@ -9,5 +9,7 @@ namespace MDFe.Servicos.EventosMDFe.Contratos
     public interface IServicoController
     {
         MDFeRetEventoMDFe Executar(MDFeEletronico mdfe, byte sequenciaEvento, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento, MDFeConfiguracao cfgMdfe = null);
+
+        MDFeRetEventoMDFe Executar(MDFeComandoEvento comando, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento, MDFeConfiguracao cfgMdfe = null);
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoCancelar.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoCancelar.cs
@@ -17,5 +17,12 @@ namespace MDFe.Servicos.EventosMDFe
 
             return retorno;
         }
+
+        public MDFeRetEventoMDFe MDFeEventoCancelar(MDFeComandoCancelamento comando, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var evento = ClassesFactory.CriaEvCancMDFe(comando.Protocolo, comando.Justificativa);
+            return new ServicoController().Executar(comando, evento, MDFeTipoEvento.Cancelamento, config);
+        }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoEncerramento.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoEncerramento.cs
@@ -28,5 +28,12 @@ namespace MDFe.Servicos.EventosMDFe
 
             return retorno;
         }
+
+        public MDFeRetEventoMDFe MDFeEventoEncerramento(MDFeComandoEncerramento comando, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var evento = ClassesFactory.CriaEvEncMDFe(comando.EstadoEncerramento, comando.CodigoMunicipioEncerramento, comando.Protocolo);
+            return new ServicoController().Executar(comando, evento, MDFeTipoEvento.Encerramento, config);
+        }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoInclusaoCondutor.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoInclusaoCondutor.cs
@@ -12,10 +12,14 @@ namespace MDFe.Servicos.EventosMDFe
         {
             var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var incluirCodutor = ClassesFactory.CriaEvIncCondutorMDFe(nome, cpf);
+            return new ServicoController().Executar(mdfe, sequenciaEvento, incluirCodutor, MDFeTipoEvento.InclusaoDeCondutor, config);
+        }
 
-            var retorno = new ServicoController().Executar(mdfe, sequenciaEvento, incluirCodutor, MDFeTipoEvento.InclusaoDeCondutor, config);
-
-            return retorno;
+        public MDFeRetEventoMDFe MDFeEventoIncluirCondutor(MDFeComandoInclusaoCondutor comando, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var evento = ClassesFactory.CriaEvIncCondutorMDFe(comando.Nome, comando.CpfCondutor);
+            return new ServicoController().Executar(comando, evento, MDFeTipoEvento.InclusaoDeCondutor, config);
         }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoInclusaoDFe.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoInclusaoDFe.cs
@@ -15,8 +15,14 @@ namespace MDFe.Servicos.EventosMDFe
         {
             var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
             var inclusao = ClassesFactory.CriaEvIncDFeMDFe(protocolo, codigoMunicipioCarregamento, nomeMunicipioCarregamento, informacoesDocumentos);
-
             return new ServicoController().Executar(mdfe, sequenciaEvento, inclusao, MDFeTipoEvento.InclusaoDFe, config);
+        }
+
+        public MDFeRetEventoMDFe MDFeEventoIncluirDFe(MDFeComandoInclusaoDFe comando, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var evento = ClassesFactory.CriaEvIncDFeMDFe(comando.Protocolo, comando.CodigoMunicipioCarregamento, comando.NomeMunicipioCarregamento, comando.InformacoesDocumentos);
+            return new ServicoController().Executar(comando, evento, MDFeTipoEvento.InclusaoDFe, config);
         }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/EventoPagamentoOperacao.cs
+++ b/MDFe.Servicos/EventosMDFe/EventoPagamentoOperacao.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using MDFe.Classes.Informacoes;
 using MDFe.Classes.Informacoes.Evento.CorpoEvento;
 using MDFe.Classes.Informacoes.Evento.Flags;
@@ -14,13 +14,15 @@ namespace MDFe.Servicos.EventosMDFe
             string protocolo, infViagens infViagens, List<infPag> infPagamentos, MDFeConfiguracao cfgMdfe = null)
         {
             var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
-            var eventoPagamento = ClassesFactory.CriaEvPagtoOperMDFe(
-                protocolo
-                , infViagens
-                , infPagamentos
-            );
-
+            var eventoPagamento = ClassesFactory.CriaEvPagtoOperMDFe(protocolo, infViagens, infPagamentos);
             return new ServicoController().Executar(mdfe, sequencia, eventoPagamento, MDFeTipoEvento.PagamentoOperacaoMDFe, config);
+        }
+
+        public MDFeRetEventoMDFe MDFeEventoPagamentoOperacao(MDFeComandoPagamentoOperacao comando, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var evento = ClassesFactory.CriaEvPagtoOperMDFe(comando.Protocolo, comando.InfViagens, comando.Pagamentos);
+            return new ServicoController().Executar(comando, evento, MDFeTipoEvento.PagamentoOperacaoMDFe, config);
         }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/FactoryEvento.cs
+++ b/MDFe.Servicos/EventosMDFe/FactoryEvento.cs
@@ -44,5 +44,40 @@ namespace MDFe.Servicos.EventosMDFe
 
             return eventoMDFe;
         }
+
+        public static MDFeEventoMDFe CriaEvento(MDFeComandoEvento comando, MDFeTipoEvento tipoEvento, MDFeEventoContainer evento, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var eventoMDFe = new MDFeEventoMDFe
+            {
+                Versao = config.VersaoWebService.VersaoLayout,
+                InfEvento = new MDFeInfEvento
+                {
+                    Id = "ID" + (long)tipoEvento + comando.Chave + comando.SequenciaEvento.ToString("D2"),
+                    TpAmb = config.VersaoWebService.TipoAmbiente,
+                    COrgao = comando.UfEmitente,
+                    ChMDFe = comando.Chave,
+                    DetEvento = new MDFeDetEvento
+                    {
+                        VersaoServico = config.VersaoWebService.VersaoLayout,
+                        EventoContainer = evento
+                    },
+                    DhEvento = DateTime.Now,
+                    NSeqEvento = comando.SequenciaEvento,
+                    TpEvento = tipoEvento
+                }
+            };
+
+            eventoMDFe.InfEvento.CNPJ = comando.CnpjEmitente;
+
+            if (!string.IsNullOrEmpty(comando.CpfEmitente))
+            {
+                eventoMDFe.InfEvento.CPF = comando.CpfEmitente;
+            }
+
+            eventoMDFe.Assinar(config);
+
+            return eventoMDFe;
+        }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/MDFeComandoCancelamento.cs
+++ b/MDFe.Servicos/EventosMDFe/MDFeComandoCancelamento.cs
@@ -1,0 +1,11 @@
+namespace MDFe.Servicos.EventosMDFe
+{
+    /// <summary>
+    ///     Dados para emitir o evento de cancelamento de MDFe.
+    /// </summary>
+    public class MDFeComandoCancelamento : MDFeComandoEvento
+    {        
+        public string Protocolo { get; set; }
+        public string Justificativa { get; set; }
+    }
+}

--- a/MDFe.Servicos/EventosMDFe/MDFeComandoEncerramento.cs
+++ b/MDFe.Servicos/EventosMDFe/MDFeComandoEncerramento.cs
@@ -1,0 +1,14 @@
+using DFe.Classes.Entidades;
+
+namespace MDFe.Servicos.EventosMDFe
+{
+    /// <summary>
+    ///     Dados para emitir o evento de encerramento de MDFe.
+    /// </summary>
+    public class MDFeComandoEncerramento : MDFeComandoEvento
+    {
+        public string Protocolo { get; set; }
+        public Estado EstadoEncerramento { get; set; }
+        public long CodigoMunicipioEncerramento { get; set; }
+    }
+}

--- a/MDFe.Servicos/EventosMDFe/MDFeComandoEvento.cs
+++ b/MDFe.Servicos/EventosMDFe/MDFeComandoEvento.cs
@@ -1,0 +1,18 @@
+using DFe.Classes.Entidades;
+
+namespace MDFe.Servicos.EventosMDFe
+{
+    /// <summary>
+    /// Base abstrata com os dados mínimos necessários 
+    /// para emitir um evento de MDFe sem depender 
+    /// do objeto "<see cref="MDFe.Classes.Informacoes.MDFe" />" completo.
+    /// </summary>
+    public abstract class MDFeComandoEvento
+    {        
+        public string Chave { get; set; }
+        public Estado UfEmitente { get; set; }        
+        public string CnpjEmitente { get; set; }        
+        public string CpfEmitente { get; set; }        
+        public byte SequenciaEvento { get; set; }
+    }
+}

--- a/MDFe.Servicos/EventosMDFe/MDFeComandoInclusaoCondutor.cs
+++ b/MDFe.Servicos/EventosMDFe/MDFeComandoInclusaoCondutor.cs
@@ -1,0 +1,11 @@
+namespace MDFe.Servicos.EventosMDFe
+{
+    /// <summary>
+    ///     Dados para emitir o evento de inclusão de condutor no MDFe.
+    /// </summary>
+    public class MDFeComandoInclusaoCondutor : MDFeComandoEvento
+    {        
+        public string Nome { get; set; }        
+        public string CpfCondutor { get; set; }
+    }
+}

--- a/MDFe.Servicos/EventosMDFe/MDFeComandoInclusaoDFe.cs
+++ b/MDFe.Servicos/EventosMDFe/MDFeComandoInclusaoDFe.cs
@@ -1,0 +1,16 @@
+using MDFe.Classes.Informacoes.Evento.CorpoEvento;
+using System.Collections.Generic;
+
+namespace MDFe.Servicos.EventosMDFe
+{
+    /// <summary>
+    ///     Dados para emitir o evento de inclusão de DF-e no MDFe.
+    /// </summary>
+    public class MDFeComandoInclusaoDFe : MDFeComandoEvento
+    {        
+        public string Protocolo { get; set; }        
+        public string CodigoMunicipioCarregamento { get; set; }
+        public string NomeMunicipioCarregamento { get; set; }
+        public List<MDFeInfDocInc> InformacoesDocumentos { get; set; }
+    }
+}

--- a/MDFe.Servicos/EventosMDFe/MDFeComandoPagamentoOperacao.cs
+++ b/MDFe.Servicos/EventosMDFe/MDFeComandoPagamentoOperacao.cs
@@ -1,0 +1,16 @@
+using MDFe.Classes.Informacoes;
+using MDFe.Classes.Informacoes.Evento.CorpoEvento;
+using System.Collections.Generic;
+
+namespace MDFe.Servicos.EventosMDFe
+{
+    /// <summary>
+    ///     Dados para emitir o evento de pagamento de operação de transporte.
+    /// </summary>
+    public class MDFeComandoPagamentoOperacao : MDFeComandoEvento
+    {        
+        public string Protocolo { get; set; }
+        public infViagens InfViagens { get; set; }
+        public List<infPag> Pagamentos { get; set; }
+    }
+}

--- a/MDFe.Servicos/EventosMDFe/ServicoController.cs
+++ b/MDFe.Servicos/EventosMDFe/ServicoController.cs
@@ -34,5 +34,22 @@ namespace MDFe.Servicos.EventosMDFe
 
             return retorno;
         }
+
+        public MDFeRetEventoMDFe Executar(MDFeComandoEvento comando, MDFeEventoContainer eventoContainer, MDFeTipoEvento tipoEvento, MDFeConfiguracao cfgMdfe = null)
+        {
+            var config = cfgMdfe ?? MDFeConfiguracao.Instancia;
+            var evento = FactoryEvento.CriaEvento(comando, tipoEvento, eventoContainer, config);
+
+            evento.ValidarSchema(config);
+            evento.SalvarXmlEmDisco(comando.Chave, config);
+
+            var webService = WsdlFactory.CriaWsdlMDFeRecepcaoEvento(config);
+            var retornoXml = webService.mdfeRecepcaoEvento(evento.CriaXmlRequestWs());
+
+            var retorno = MDFeRetEventoMDFe.LoadXml(retornoXml.OuterXml, evento);
+            retorno.SalvarXmlEmDisco(comando.Chave, config);
+
+            return retorno;
+        }
     }
 }

--- a/MDFe.Servicos/EventosMDFe/ServicoMDFeEvento.cs
+++ b/MDFe.Servicos/EventosMDFe/ServicoMDFeEvento.cs
@@ -20,6 +20,11 @@ namespace MDFe.Servicos.EventosMDFe
             return eventoIncluirCondutor.MDFeEventoIncluirCondutor(mdfe, sequenciaEvento, nome, cpf, config);
         }
 
+        public MDFeRetEventoMDFe MDFeEventoIncluirCondutor(MDFeComandoInclusaoCondutor cmd, MDFeConfiguracao cfgMdfe = null)
+        {
+            return new EventoInclusaoCondutor().MDFeEventoIncluirCondutor(cmd, cfgMdfe);
+        }
+
         public MDFeRetEventoMDFe MDFeEventoIncluirDFe(
             MDFeEletronica mdfe, byte sequenciaEvento, string protocolo,
             string codigoMunicipioCarregamento, string nomeMunicipioCarregamento, List<MDFeInfDocInc> informacoesDocumentos, MDFeConfiguracao cfgMdfe = null)
@@ -28,6 +33,11 @@ namespace MDFe.Servicos.EventosMDFe
             var eventoIncluirDFe = new EventoInclusaoDFe();
 
             return eventoIncluirDFe.MDFeEventoIncluirDFe(mdfe, sequenciaEvento, protocolo, codigoMunicipioCarregamento, nomeMunicipioCarregamento, informacoesDocumentos, config);
+        }
+
+        public MDFeRetEventoMDFe MDFeEventoIncluirDFe(MDFeComandoInclusaoDFe cmd, MDFeConfiguracao cfgMdfe = null)
+        {
+            return new EventoInclusaoDFe().MDFeEventoIncluirDFe(cmd, cfgMdfe);
         }
 
         public MDFeRetEventoMDFe MDFeEventoEncerramentoMDFeEventoEncerramento(MDFeEletronica mdfe, byte sequenciaEvento, string protocolo, MDFeConfiguracao cfgMdfe = null)
@@ -46,6 +56,11 @@ namespace MDFe.Servicos.EventosMDFe
             return eventoEncerramento.MDFeEventoEncerramento(mdfe, estadoEncerramento, codigoMunicipioEncerramento, sequenciaEvento, protocolo, config);
         }
 
+        public MDFeRetEventoMDFe MDFeEventoEncerramentoMDFeEventoEncerramento(MDFeComandoEncerramento cmd, MDFeConfiguracao cfgMdfe = null)
+        {
+            return new EventoEncerramento().MDFeEventoEncerramento(cmd, cfgMdfe);
+        }
+
         public MDFeRetEventoMDFe MDFeEventoCancelar(MDFeEletronica mdfe, byte sequenciaEvento, string protocolo,
             string justificativa, MDFeConfiguracao cfgMdfe = null)
         {
@@ -53,6 +68,11 @@ namespace MDFe.Servicos.EventosMDFe
             var eventoCancelamento = new EventoCancelar();
 
             return eventoCancelamento.MDFeEventoCancelar(mdfe, sequenciaEvento, protocolo, justificativa, config);
+        }
+
+        public MDFeRetEventoMDFe MDFeEventoCancelar(MDFeComandoCancelamento cmd, MDFeConfiguracao cfgMdfe = null)
+        {
+            return new EventoCancelar().MDFeEventoCancelar(cmd, cfgMdfe);
         }
 
         public MDFeRetEventoMDFe MDFeEventoPagamentoOperacaoTransporte(MDFeEletronica mdfe, byte sequenciaEvneto,
@@ -63,6 +83,11 @@ namespace MDFe.Servicos.EventosMDFe
 
             return eventoPagamentoOperacao.MDFeEventoPagamentoOperacao(mdfe, sequenciaEvneto, protocolo,
                 infViagens, infPagamentos, config);
+        }
+
+        public MDFeRetEventoMDFe MDFeEventoPagamentoOperacaoTransporte(MDFeComandoPagamentoOperacao cmd, MDFeConfiguracao cfgMdfe = null)
+        {
+            return new EventoPagamentoOperacao().MDFeEventoPagamentoOperacao(cmd, cfgMdfe);
         }
     }
 }


### PR DESCRIPTION
Hoje a emissão de qualquer evento de MDF-e (encerramento, cancelamento, inclusão de condutor, inclusão de DF-e e pagamento) exige o objeto `MDFeEletronico` inteiro, mesmo o evento consumindo apenas quatro campos: chave, UF, CNPJ/CPF do emitente e código IBGE do município.

Isso gera dois problemas:

1 - Quando o sistema não possui o XML do MDF-e e tem apenas a chave e o protocolo (como em consultas de MDF-es não encerrados ou dados vindos do banco), não é possível emitir os eventos diretamente. 
É necessário consultar o MDF-e, desserializar o XML e reconstruir um objeto "MDFeEletronico" inteiro, embora o evento utilize apenas quatro informações.

2 - Em aplicacoes que processam eventos em lote (cancelamentos, encerramentos programados, etc.) precisam trafegar e reconstruir um objeto "MDFeEletronico" completo para cada evento apenas para acessar esses quatro campos, isso adiciona consumo de serialização desnecessariamente.
