### PR TITLE
Permitindo emitir eventos de desacordo e cancelamento de desacordo de CTe para UF diferente da configurada no emitente

### DIFF
--- a/CTe.AppTeste/CTeTesteModel.cs
+++ b/CTe.AppTeste/CTeTesteModel.cs
@@ -569,9 +569,10 @@ namespace CTe.AppTeste
         {
             var configuracaoCertificado = new ConfiguracaoCertificado
             {
+                TipoCertificado = TipoCertificado.A1Arquivo,
                 Arquivo = config.CertificadoDigital.CaminhoArquivo,
-                TipoCertificado = TipoCertificado.A1Repositorio,
                 ManterDadosEmCache = config.CertificadoDigital.ManterEmCache,
+                Senha = config.CertificadoDigital.Senha,
                 Serial = config.CertificadoDigital.NumeroDeSerie
             };
 

--- a/CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
+++ b/CTe.Servicos/Enderecos/Helpers/UrlHelper.cs
@@ -9,36 +9,51 @@ namespace CTe.Servicos.Enderecos.Helpers
 {
     public class UrlHelper
     {
-        public static UrlCTe ObterUrlServico(ConfiguracaoServico configuracaoServico = null)
+        /// <summary>
+        /// Obtem a url de Serviço. Por padrão pega as informações de ConfiguracaoServico, mas pode ser customizada individualmente. Motivo: em alguns casos a url de destino de um evento de CTe pode seguir as informações do xml e não da empresa emissora / com certificado ativo
+        /// </summary>
+        /// <param name="configuracaoServico"></param>
+        /// <param name="tipoEmissao"></param>
+        /// <param name="tipoAmbiente"></param>
+        /// <param name="ufRecepcao"></param>
+        /// <param name="versaoLayout"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        public static UrlCTe ObterUrlServico(ConfiguracaoServico configuracaoServico = null, tpEmis? tipoEmissao = null , TipoAmbiente? tipoAmbiente = null, Estado? ufRecepcao = null, versao? versaoLayout = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            switch (configServico.tpAmb)
+            var _tpEmissao = tipoEmissao ?? configServico.TipoEmissao;
+            var _tpAmb = tipoAmbiente ?? configServico.tpAmb;
+            var _cUF = ufRecepcao ?? configServico.cUF;
+            var _versao = versaoLayout ?? configServico.VersaoLayout;
+
+            switch (_tpAmb)
             {
                 case TipoAmbiente.Homologacao:
-                    if (configServico.TipoEmissao == tpEmis.teSVCRS)
+                    if (_tpEmissao == tpEmis.teSVCRS)
                     {
-                        return UrlHomologacaoSvrs(configServico);
+                        return UrlHomologacaoSvrs(_versao);
                     }
 
-                    if (configServico.TipoEmissao == tpEmis.teSVCSP)
+                    if (_tpEmissao == tpEmis.teSVCSP)
                     {
-                        return UrlHomologacaoSvcsp(configServico);
+                        return UrlHomologacaoSvcsp(_versao);
                     }
 
-                    return UrlHomologacao(configServico);
+                    return UrlHomologacao(_cUF, _versao);
                 case TipoAmbiente.Producao:
-                    if (configServico.TipoEmissao == tpEmis.teSVCRS)
+                    if (_tpEmissao == tpEmis.teSVCRS)
                     {
-                        return UrlProducaoSvrs(configServico);
+                        return UrlProducaoSvrs(_versao);
                     }
 
-                    if (configServico.TipoEmissao == tpEmis.teSVCSP)
+                    if (_tpEmissao == tpEmis.teSVCSP)
                     {
-                        return UrlProducaoSvcsp(configServico);
+                        return UrlProducaoSvcsp(_versao);
                     }
 
-                    return UrlProducao(configServico);
+                    return UrlProducao(_cUF, _versao);
             }
 
             throw new InvalidOperationException("Tipo Ambiente inválido");
@@ -51,17 +66,17 @@ namespace CTe.Servicos.Enderecos.Helpers
             switch (configServico.tpAmb)
             {
                 case TipoAmbiente.Homologacao:
-                    return UrlHomologacao(configServico).QrCode;
+                    return UrlHomologacao(configServico.cUF, configServico.VersaoLayout).QrCode;
                 case TipoAmbiente.Producao:
-                    return UrlProducao(configServico).QrCode;
+                    return UrlProducao(configServico.cUF, configServico.VersaoLayout).QrCode;
             }
 
             throw new InvalidOperationException("Tipo Ambiente inválido");
         }
 
-        private static UrlCTe UrlProducaoSvcsp(ConfiguracaoServico configuracaoServico)
+        private static UrlCTe UrlProducaoSvcsp(versao VersaoLayout)
         {
-            if (configuracaoServico.VersaoLayout == versao.ve400)
+            if (VersaoLayout == versao.ve400)
             {
                 return new UrlCTe
                 {
@@ -86,9 +101,9 @@ namespace CTe.Servicos.Enderecos.Helpers
             };
         }
 
-        private static UrlCTe UrlHomologacaoSvcsp(ConfiguracaoServico configuracaoServico)
+        private static UrlCTe UrlHomologacaoSvcsp(versao VersaoLayout)
         {
-            if (configuracaoServico.VersaoLayout == versao.ve400)
+            if (VersaoLayout == versao.ve400)
             {
                 return new UrlCTe
                 {
@@ -113,9 +128,9 @@ namespace CTe.Servicos.Enderecos.Helpers
             };
         }
 
-        private static UrlCTe UrlHomologacaoSvrs(ConfiguracaoServico configuracaoServico)
+        private static UrlCTe UrlHomologacaoSvrs(versao VersaoLayout)
         {
-            if (configuracaoServico.VersaoLayout == versao.ve400)
+            if (VersaoLayout == versao.ve400)
             {
                 return new UrlCTe
                 {
@@ -141,9 +156,9 @@ namespace CTe.Servicos.Enderecos.Helpers
             };
         }
 
-        private static UrlCTe UrlProducaoSvrs(ConfiguracaoServico configuracaoServico)
+        private static UrlCTe UrlProducaoSvrs(versao VersaoLayout)
         {
-            if (configuracaoServico.VersaoLayout == versao.ve400)
+            if (VersaoLayout == versao.ve400)
             {
                 return new UrlCTe
                 {
@@ -169,12 +184,12 @@ namespace CTe.Servicos.Enderecos.Helpers
             };
         }
 
-        private static UrlCTe UrlProducao(ConfiguracaoServico configuracaoServico)
+        private static UrlCTe UrlProducao(Estado UFRecepcao, versao VersaoLayout)
         {
-            switch (configuracaoServico.cUF)
+            switch (UFRecepcao)
             {
                 case Estado.MT:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -200,7 +215,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.MS:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -226,7 +241,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.MG:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -252,7 +267,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.PR:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -278,7 +293,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = "https://www1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.SP:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -326,7 +341,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                 case Estado.SE:
                 case Estado.TO:
                 case Estado.RS:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -357,7 +372,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                 case Estado.AP:
                 case Estado.PE:
                 case Estado.RR:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -389,12 +404,12 @@ namespace CTe.Servicos.Enderecos.Helpers
 
         }
 
-        private static UrlCTe UrlHomologacao(ConfiguracaoServico configuracaoServico)
+        private static UrlCTe UrlHomologacao(Estado UFRecepcao, versao VersaoLayout)
         {
-            switch (configuracaoServico.cUF)
+            switch (UFRecepcao)
             {
                 case Estado.MT:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -421,7 +436,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = @"https://hom1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.MS:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -445,7 +460,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = @"https://hom1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.MG:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -471,7 +486,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = @"https://hom1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.PR:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -512,7 +527,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                         CTeDistribuicaoDFe = @"https://hom1.cte.fazenda.gov.br/CTeDistribuicaoDFe/CTeDistribuicaoDFe.asmx"
                     };
                 case Estado.SP:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -555,7 +570,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                 case Estado.SC:
                 case Estado.SE:
                 case Estado.TO:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {
@@ -586,7 +601,7 @@ namespace CTe.Servicos.Enderecos.Helpers
                 case Estado.AP:
                 case Estado.PE:
                 case Estado.RR:
-                    if (configuracaoServico.VersaoLayout == versao.ve400)
+                    if (VersaoLayout == versao.ve400)
                     {
                         return new UrlCTe
                         {

--- a/CTe.Servicos/Eventos/EventoCancelamentoDesacordo.cs
+++ b/CTe.Servicos/Eventos/EventoCancelamentoDesacordo.cs
@@ -41,7 +41,7 @@ namespace CTe.Servicos.Eventos
             var eventoCancelaDiscordar = ClassesFactory.CriaEvCancPrestDesacordo(_nProtEvPrestDes);
 
             EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico, orgaoEmissor);
-            RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico);
+            RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico, orgaoEmissor);
 
             return RetornoSefaz;
         }

--- a/CTe.Servicos/Eventos/EventoCancelamentoDesacordo.cs
+++ b/CTe.Servicos/Eventos/EventoCancelamentoDesacordo.cs
@@ -24,23 +24,23 @@ namespace CTe.Servicos.Eventos
             _nProtEvPrestDes = nProtEvPrestDes;
         }
 
-        public retEventoCTe CancelarDesacordo(ConfiguracaoServico configuracaoServico = null)
+        public retEventoCTe CancelarDesacordo(ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? orgaoEmissor = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var eventoCancelaDiscordar = ClassesFactory.CriaEvCancPrestDesacordo(_nProtEvPrestDes);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico);
-            RetornoSefaz = new ServicoController().Executar(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico, orgaoEmissor);
+            RetornoSefaz = new ServicoController().Executar(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico, orgaoEmissor);
 
             return RetornoSefaz;
         }
 
-        public async Task<retEventoCTe> CancelarDesacordoAsync(ConfiguracaoServico configuracaoServico = null)
+        public async Task<retEventoCTe> CancelarDesacordoAsync(ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? orgaoEmissor = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var eventoCancelaDiscordar = ClassesFactory.CriaEvCancPrestDesacordo(_nProtEvPrestDes);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico, orgaoEmissor);
             RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.CancelamentoPrestacaodoServicoemDesacordo, _sequenciaEvento, _chave, _cnpj, eventoCancelaDiscordar, configServico);
 
             return RetornoSefaz;

--- a/CTe.Servicos/Eventos/EventoDesacordo.cs
+++ b/CTe.Servicos/Eventos/EventoDesacordo.cs
@@ -26,23 +26,35 @@ namespace CTe.Servicos.Eventos
             _observacao = observacao;
         }
 
+        /// <summary>
+        /// Gera o evento de desacordo de CTe
+        /// </summary>
+        /// <param name="configuracaoServico"></param>
+        /// <param name="orgaoEmissor">Sempre considera a UF que gerou o xml. Então a empresa pode estar configurada para uma UF X e gerar o desacordo de um xml gerando na UF Y, sendo o evento, portando, enviado para UF Y</param>
+        /// <returns></returns>
         public retEventoCTe Discordar(ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? orgaoEmissor = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var eventoDiscordar = ClassesFactory.CriaEvPrestDesacordo(_indicadorDesacordo, _observacao);
 
             EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico, orgaoEmissor);
-            RetornoSefaz = new ServicoController().Executar(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico);
+            RetornoSefaz = new ServicoController().Executar(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico, orgaoEmissor);
             return RetornoSefaz;
         }
 
+        /// <summary>
+        /// Gera o evento de cancelamento de desacordo de CTe
+        /// </summary>
+        /// <param name="configuracaoServico"></param>
+        /// <param name="orgaoEmissor">Sempre considera a UF que gerou o xml. Então a empresa pode estar configurada para uma UF X e gerar o cancelmaento para um xml gerado na UF Y, sendo o evento, portando, enviado para UF Y</param>
+        /// <returns></returns>
         public async Task<retEventoCTe> DiscordarAsync(ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? orgaoEmissor = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var eventoDiscordar = ClassesFactory.CriaEvPrestDesacordo(_indicadorDesacordo, _observacao);
 
             EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico, orgaoEmissor);
-            RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico);
+            RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico, orgaoEmissor);
             return RetornoSefaz;
         }
     }

--- a/CTe.Servicos/Eventos/EventoDesacordo.cs
+++ b/CTe.Servicos/Eventos/EventoDesacordo.cs
@@ -26,22 +26,22 @@ namespace CTe.Servicos.Eventos
             _observacao = observacao;
         }
 
-        public retEventoCTe Discordar(ConfiguracaoServico configuracaoServico = null)
+        public retEventoCTe Discordar(ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? orgaoEmissor = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var eventoDiscordar = ClassesFactory.CriaEvPrestDesacordo(_indicadorDesacordo, _observacao);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico, orgaoEmissor);
             RetornoSefaz = new ServicoController().Executar(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico);
             return RetornoSefaz;
         }
 
-        public async Task<retEventoCTe> DiscordarAsync(ConfiguracaoServico configuracaoServico = null)
+        public async Task<retEventoCTe> DiscordarAsync(ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? orgaoEmissor = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
             var eventoDiscordar = ClassesFactory.CriaEvPrestDesacordo(_indicadorDesacordo, _observacao);
 
-            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico);
+            EventoEnviado = FactoryEvento.CriaEvento(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico, orgaoEmissor);
             RetornoSefaz = await new ServicoController().ExecutarAsync(CTeTipoEvento.Desacordo, _sequenciaEvento, _chave, _cnpj, eventoDiscordar, configServico);
             return RetornoSefaz;
         }

--- a/CTe.Servicos/Eventos/FactoryEvento.cs
+++ b/CTe.Servicos/Eventos/FactoryEvento.cs
@@ -18,7 +18,7 @@ namespace CTe.Servicos.Eventos
             return CriaEvento(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configServico);
         }
 
-        public static eventoCTe CriaEvento(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
+        public static eventoCTe CriaEvento(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? cOrgao = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
@@ -39,7 +39,7 @@ namespace CTe.Servicos.Eventos
                 {
                     tpAmb = configServico.tpAmb,
                     CNPJ = cnpj,
-                    cOrgao = configServico.cUF,
+                    cOrgao = cOrgao ?? configServico.cUF,
                     chCTe = chave,
                     dhEvento = DateTimeOffset.Now,
                     nSeqEvento = sequenciaEvento,

--- a/CTe.Servicos/Eventos/ServicoController.cs
+++ b/CTe.Servicos/Eventos/ServicoController.cs
@@ -33,10 +33,10 @@ namespace CTe.Servicos.Eventos
             return await ExecutarAsync(cTeTipoEvento, sequenciaEvento, cte.Chave(), cte.infCte.emit.CNPJ, container, configServico);
         }
 
-        public retEventoCTe Executar(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null)
+        public retEventoCTe Executar(CTeTipoEvento cTeTipoEvento, int sequenciaEvento, string chave, string cnpj, EventoContainer container, ConfiguracaoServico configuracaoServico = null, DFe.Classes.Entidades.Estado? cOrgao = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
-            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico);
+            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico, cOrgao);
             evento.Assina(configServico);
 
             if (configuracaoServico.IsValidaSchemas)
@@ -68,11 +68,12 @@ namespace CTe.Servicos.Eventos
             int sequenciaEvento,
             string chave, string
             cnpj, EventoContainer container,
-            ConfiguracaoServico configuracaoServico = null)
+            ConfiguracaoServico configuracaoServico = null, 
+            DFe.Classes.Entidades.Estado? cOrgao = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico);
+            var evento = FactoryEvento.CriaEvento(cTeTipoEvento, sequenciaEvento, chave, cnpj, container, configServico, cOrgao);
             evento.Assina(configServico);
 
             if (configServico.IsValidaSchemas)

--- a/CTe.Servicos/Eventos/ServicoController.cs
+++ b/CTe.Servicos/Eventos/ServicoController.cs
@@ -81,7 +81,7 @@ namespace CTe.Servicos.Eventos
 
             evento.SalvarXmlEmDisco(configServico);
 
-            var webService = WsdlFactory.CriaWsdlCteEvento(configServico);
+            var webService = WsdlFactory.CriaWsdlCteEvento(configServico, ufUrl: cOrgao);
             var retornoXml = await webService.cteRecepcaoEventoAsync(evento.CriaXmlRequestWs());
 
             var retorno = retEventoCTe.LoadXml(retornoXml.OuterXml, evento);

--- a/CTe.Servicos/Eventos/ServicoController.cs
+++ b/CTe.Servicos/Eventos/ServicoController.cs
@@ -48,13 +48,13 @@ namespace CTe.Servicos.Eventos
 
             if (evento.versao == versao.ve200 || evento.versao == versao.ve300)
             {
-                var webService = WsdlFactory.CriaWsdlCteEvento(configServico);
+                var webService = WsdlFactory.CriaWsdlCteEvento(configServico, ufUrl: cOrgao);
                 retornoXml = webService.cteRecepcaoEvento(evento.CriaXmlRequestWs());
             }
 
             if (evento.versao == versao.ve400)
             {
-                var webService = WsdlFactory.CriaWsdlCteEventoV4(configServico);
+                var webService = WsdlFactory.CriaWsdlCteEventoV4(configServico, ufUrl: cOrgao);
                 retornoXml = webService.cteRecepcaoEvento(evento.CriaXmlRequestWs());
             }
 

--- a/CTe.Servicos/Factory/WsdlFactory.cs
+++ b/CTe.Servicos/Factory/WsdlFactory.cs
@@ -14,6 +14,7 @@ using CTe.Wsdl.ConsultaProtocolo.V4;
 using CTe.Wsdl.Evento.V4;
 using CTe.Wsdl.Recepcao.Sincrono;
 using System.Security.Cryptography.X509Certificates;
+using DFe.Classes.Entidades;
 
 namespace CTe.Servicos.Factory
 {
@@ -90,22 +91,22 @@ namespace CTe.Servicos.Factory
             return new CteRecepcaoSincronoOSV4(configuracaoWsdl);
         }
 
-        public static CteRecepcaoEvento CriaWsdlCteEvento(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
+        public static CteRecepcaoEvento CriaWsdlCteEvento(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null, Estado? ufUrl = null)
         {
-            var url = UrlHelper.ObterUrlServico(configuracaoServico).CteRecepcaoEvento;
+            var url = UrlHelper.ObterUrlServico(configuracaoServico, ufRecepcao: ufUrl).CteRecepcaoEvento;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado);
+            var configuracaoWsdl = CriaConfiguracao(url, configuracaoServico, certificado, ufUrl);
 
             return new CteRecepcaoEvento(configuracaoWsdl);
         }
 
-        public static CteRecepcaoEventoV4 CriaWsdlCteEventoV4(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null)
+        public static CteRecepcaoEventoV4 CriaWsdlCteEventoV4(ConfiguracaoServico configuracaoServico = null, X509Certificate2 certificado = null, Estado? ufUrl = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var url = UrlHelper.ObterUrlServico(configServico).CteRecepcaoEvento;
+            var url = UrlHelper.ObterUrlServico(configServico, ufRecepcao: ufUrl).CteRecepcaoEvento;
 
-            var configuracaoWsdl = CriaConfiguracao(url, configServico, certificado);
+            var configuracaoWsdl = CriaConfiguracao(url, configServico, certificado, ufUrl);
 
             return new CteRecepcaoEventoV4(configuracaoWsdl);
         }
@@ -121,11 +122,11 @@ namespace CTe.Servicos.Factory
         }
 
 
-        private static WsdlConfiguracao CriaConfiguracao(string url, ConfiguracaoServico configuracaoServico, X509Certificate2 certificado)
+        private static WsdlConfiguracao CriaConfiguracao(string url, ConfiguracaoServico configuracaoServico, X509Certificate2 certificado, Estado? ufUrl = null)
         {
             var configServico = configuracaoServico ?? ConfiguracaoServico.Instancia;
 
-            var codigoEstado = configServico.cUF.GetCodigoIbgeEmString();
+            var codigoEstado = ufUrl.HasValue ? ufUrl.Value.GetCodigoIbgeEmString() : configServico.cUF.GetCodigoIbgeEmString();
             var certificadoDigital = certificado ?? configServico.X509Certificate2;
             var versaoEmString = configServico.VersaoLayout.GetString();
             var timeOut = configServico.TimeOut;


### PR DESCRIPTION
## Motivo: 
Em alguns eventos de desacordo o emitente (empresa com certificado digital no projeto) pode estar em um Estado (Unidade Federativa) diferente de onde o xml de CTe foi emitido. Porém, para realizar esse evento, a url e orgão de destino do evento devem ser para o Estado de emissão do CTe.
### Observação:
A regra da UF / Url de destino do evento teoricamente serve para outros eventos do CTe, porém eles não foram modificados