### PR TITLE
feat: transmitir eventos já assinados fora da biblioteca

### DIFF
--- a/DFe.Testes/Gerais/ObterIdTestes.cs
+++ b/DFe.Testes/Gerais/ObterIdTestes.cs
@@ -1,0 +1,61 @@
+using DFe.Classes.Entidades;
+using DFe.Classes.Flags;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NFe.Classes.Servicos.Tipos;
+using NFe.Utils.Evento;
+using NFe.Utils.Inutilizacao;
+
+namespace DFe.Testes.Gerais
+{
+    /// <summary>
+    ///     Vetores ouro do Id assinável de evento (infEvento/@Id) e de inutilização (infInut/@Id).
+    ///     <para>
+    ///         Esses Ids também são calculados internamente pelos métodos que assinam (ServicosNFe). Se o formato
+    ///         divergir, o digest da assinatura não bate e o SEFAZ rejeita — por isso os valores esperados aqui são
+    ///         literais do layout, e não o resultado do próprio método.
+    ///     </para>
+    /// </summary>
+    [TestClass]
+    public class ObterIdTestes
+    {
+        /// <summary>Chave de NF-e (modelo 55) com CNPJ alfanumérico, conforme NT Conjunta 2025.001</summary>
+        private const string ChaveNFe = "522507PC3D315K000193550010000000011000000018";
+
+        /// <summary>Chave de NFC-e (modelo 65), 100% numérica</summary>
+        private const string ChaveNFCe = "23190811820016000167650010000000221100000227";
+
+        private const string CnpjNumerico = "11820016000167";
+        private const string CnpjAlfanumerico = "PC3D315K000193";
+
+        [TestMethod]
+        [DataRow(NFeTipoEvento.TeNfeCancelamento, ChaveNFe, 1, "ID110111" + ChaveNFe + "01",
+            DisplayName = "Cancelamento, chave com CNPJ alfanumérico")]
+        [DataRow(NFeTipoEvento.TeNfeCartaCorrecao, ChaveNFe, 2, "ID110110" + ChaveNFe + "02",
+            DisplayName = "Carta de Correção, 2ª sequência")]
+        [DataRow(NFeTipoEvento.TeMdCienciaDaOperacao, ChaveNFCe, 1, "ID210210" + ChaveNFCe + "01",
+            DisplayName = "Ciência da Operação, chave numérica")]
+        [DataRow(NFeTipoEvento.TeMdCienciaDaOperacao, ChaveNFCe, 11, "ID210210" + ChaveNFCe + "11",
+            DisplayName = "Sequência com 2 dígitos não recebe zero à esquerda")]
+        public void ObterIdEvento_SegueOLayout(NFeTipoEvento tpEvento, string chNFe, int nSeqEvento, string esperado)
+        {
+            Assert.AreEqual(esperado, Extevento.ObterId(tpEvento, chNFe, nSeqEvento));
+        }
+
+        [TestMethod]
+        [DataRow(ModeloDocumento.NFe, CnpjNumerico, 1, 1, 10,
+            "ID3525" + CnpjNumerico + "55" + "001" + "000000001" + "000000010",
+            DisplayName = "NF-e, modelo 55")]
+        [DataRow(ModeloDocumento.NFCe, CnpjNumerico, 1, 1, 10,
+            "ID3525" + CnpjNumerico + "65" + "001" + "000000001" + "000000010",
+            DisplayName = "NFC-e, modelo 65")]
+        [DataRow(ModeloDocumento.NFe, CnpjAlfanumerico, 12, 5, 5,
+            "ID3525" + CnpjAlfanumerico + "55" + "012" + "000000005" + "000000005",
+            DisplayName = "CNPJ alfanumérico, faixa de um número só")]
+        public void ObterIdInutilizacao_SegueOLayout(ModeloDocumento modelo, string cnpj, int serie,
+            int numeroInicial, int numeroFinal, string esperado)
+        {
+            Assert.AreEqual(esperado,
+                ExtinutNFe.ObterId(Estado.SP, 25, cnpj, modelo, serie, numeroInicial, numeroFinal));
+        }
+    }
+}

--- a/NFe.Servicos/ServicosNFe.cs
+++ b/NFe.Servicos/ServicosNFe.cs
@@ -676,6 +676,23 @@ namespace NFe.Servicos
         }
 
         /// <summary>
+        /// Envia eventos do tipo "Manifestação do destinatário" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoManifestacaoDestinatario(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoManifestacaoDestinatario, _cFgServico.VersaoRecepcaoEventoManifestacaoDestinatario, assinar);
+            return retorno;
+        }
+
+        /// <summary>
         ///     Envia um evento do tipo "EPEC"
         /// </summary>
         /// <param name="idlote"></param>
@@ -817,6 +834,23 @@ namespace NFe.Servicos
         }
 
         /// <summary>
+        /// Envia eventos do tipo "Insucesso na Entrega da NF-e" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoInsucessoEntrega(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoInsucessoEntregaNFe, _cFgServico.VersaoRecepcaoEventoInsucessoEntrega, assinar);
+            return retorno;
+        }
+
+        /// <summary>
         /// Serviço para cancelamento insucesso na entrega
         /// </summary>
         /// <param name="idlote">Nº do lote</param>
@@ -865,6 +899,23 @@ namespace NFe.Servicos
             var evento = new evento { versao = versaoServico, infEvento = infEvento };
 
             var retorno = RecepcaoEvento(idlote, new List<evento> { evento }, ServicoNFe.RecepcaoEventoCancInsucessoEntregaNFe, _cFgServico.VersaoRecepcaoEventoInsucessoEntrega, true);
+            return retorno;
+        }
+
+        /// <summary>
+        /// Envia eventos do tipo "Cancelamento do Insucesso na Entrega da NF-e" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoCancInsucessoEntrega(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoCancInsucessoEntregaNFe, _cFgServico.VersaoRecepcaoEventoInsucessoEntrega, assinar);
             return retorno;
         }
 
@@ -938,6 +989,23 @@ namespace NFe.Servicos
         }
 
         /// <summary>
+        /// Envia eventos do tipo "Comprovante de Entrega da NF-e" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoComprovanteEntrega(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoComprovanteEntregaNFe, _cFgServico.VersaoRecepcaoEventoComprovanteEntrega, assinar);
+            return retorno;
+        }
+
+        /// <summary>
         /// Serviço para cancelamento comprovante de entrega
         /// </summary>
         /// <param name="idlote">Nº do lote</param>
@@ -987,6 +1055,23 @@ namespace NFe.Servicos
             var evento = new evento { versao = versaoServico, infEvento = infEvento };
 
             var retorno = RecepcaoEvento(idlote, new List<evento> { evento }, ServicoNFe.RecepcaoEventoCancComprovanteEntregaNFe, _cFgServico.VersaoRecepcaoEventoComprovanteEntrega, true);
+            return retorno;
+        }
+
+        /// <summary>
+        /// Envia eventos do tipo "Cancelamento do Comprovante de Entrega da NF-e" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoCancComprovanteEntrega(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoCancComprovanteEntregaNFe, _cFgServico.VersaoRecepcaoEventoComprovanteEntrega, assinar);
             return retorno;
         }
 
@@ -1042,6 +1127,23 @@ namespace NFe.Servicos
         }
 
         /// <summary>
+        /// Envia eventos do tipo "Conciliação Financeira da NF-e" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoConciliacaoFinanceira(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoConciliacaoFinanceiraNFe, _cFgServico.VersaoRecepcaoEventoConciliacaoFinanceira, assinar);
+            return retorno;
+        }
+
+        /// <summary>
         /// Serviço para cancelamento Conciliação Financeira
         /// </summary>
         /// <param name="idlote">Nº do lote</param>
@@ -1089,6 +1191,23 @@ namespace NFe.Servicos
             var evento = new evento { versao = versaoServico, infEvento = infEvento };
 
             var retorno = RecepcaoEvento(idlote, new List<evento> { evento }, ServicoNFe.RecepcaoEventoCancConciliacaoFinanceiraNFe, _cFgServico.VersaoRecepcaoEventoConciliacaoFinanceira, true);
+            return retorno;
+        }
+
+        /// <summary>
+        /// Envia eventos do tipo "Cancelamento da Conciliação Financeira da NF-e" já assinado.
+        /// </summary>
+        /// <param name="idlote"></param>
+        /// <param name="eventos"></param>
+        /// <param name="assinar">
+        /// false (padrão) para transmitir os eventos exatamente como vieram, já assinados; true para a biblioteca
+        /// calcular o Id e assinar cada evento com o certificado desta instância de ServicosNFe, sobrescrevendo o Id
+        /// que já estiver preenchido.
+        /// </param>
+        /// <returns></returns>
+        public RetornoRecepcaoEvento RecepcaoEventoCancConciliacaoFinanceira(int idlote, List<evento> eventos, bool assinar = false)
+        {
+            var retorno = RecepcaoEvento(idlote, eventos, ServicoNFe.RecepcaoEventoCancConciliacaoFinanceiraNFe, _cFgServico.VersaoRecepcaoEventoConciliacaoFinanceira, assinar);
             return retorno;
         }
 

--- a/NFe.Utils/Evento/Extevento.cs
+++ b/NFe.Utils/Evento/Extevento.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography.X509Certificates;
 using DFe.Utils;
 using NFe.Classes.Servicos.Evento;
+using NFe.Classes.Servicos.Tipos;
 using NFe.Utils.Assinatura;
 
 namespace NFe.Utils.Evento
@@ -16,6 +17,23 @@ namespace NFe.Utils.Evento
         public static string ObterXmlString(this evento pedEvento)
         {
             return FuncoesXml.ClasseParaXmlString(pedEvento);
+        }
+
+        /// <summary>
+        ///     Obtém o Id de um evento (infEvento/@Id): literal "ID" + tpEvento + chNFe + nSeqEvento com 2 dígitos
+        ///     <para>
+        ///         Uso opcional, para quando o evento for montado fora da biblioteca — por exemplo, para assinar com o
+        ///         certificado numa máquina cliente e depois transmitir com a sobrecarga que recebe o evento já
+        ///         assinado. Os métodos que assinam internamente continuam calculando o Id sozinhos.
+        ///     </para>
+        /// </summary>
+        /// <param name="tpEvento">Código do evento</param>
+        /// <param name="chNFe">Chave de acesso da NF-e vinculada ao evento</param>
+        /// <param name="nSeqEvento">Sequencial do evento para o mesmo tipo de evento</param>
+        /// <returns>Retorna o conteúdo do atributo infEvento/@Id</returns>
+        public static string ObterId(NFeTipoEvento tpEvento, string chNFe, int nSeqEvento)
+        {
+            return "ID" + ((int)tpEvento) + chNFe + nSeqEvento.ToString().PadLeft(2, '0');
         }
 
         /// <summary>

--- a/NFe.Utils/Inutilizacao/ExtinutNFe.cs
+++ b/NFe.Utils/Inutilizacao/ExtinutNFe.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Security.Cryptography.X509Certificates;
+using DFe.Classes.Entidades;
+using DFe.Classes.Flags;
 using DFe.Utils;
 using NFe.Classes.Servicos.Inutilizacao;
 using NFe.Utils.Assinatura;
@@ -27,6 +29,36 @@ namespace NFe.Utils.Inutilizacao
         public static string ObterXmlString(this inutNFe pedInutilizacao)
         {
             return FuncoesXml.ClasseParaXmlString(pedInutilizacao);
+        }
+
+        /// <summary>
+        ///     Obtém o Id de um pedido de inutilização (infInut/@Id): literal "ID" + cUF + ano com 2 dígitos + CNPJ +
+        ///     modelo + série com 3 dígitos + número inicial e número final com 9 dígitos
+        ///     <para>
+        ///         Uso opcional, para quando o pedido for montado fora da biblioteca — por exemplo, para assinar com o
+        ///         certificado numa máquina cliente e depois transmitir com <see cref="Assina"/> já feito, via a
+        ///         sobrecarga que recebe o inutNFe pronto. O método que assina internamente continua calculando o Id
+        ///         sozinho.
+        ///     </para>
+        /// </summary>
+        /// <param name="cUF">Código da UF do solicitante</param>
+        /// <param name="ano">Ano de inutilização da numeração</param>
+        /// <param name="cnpj">CNPJ do emitente</param>
+        /// <param name="modelo">Modelo do documento</param>
+        /// <param name="serie">Série</param>
+        /// <param name="numeroInicial">Número inicial a ser inutilizado</param>
+        /// <param name="numeroFinal">Número final a ser inutilizado</param>
+        /// <returns>Retorna o conteúdo do atributo infInut/@Id</returns>
+        public static string ObterId(Estado cUF, int ano, string cnpj, ModeloDocumento modelo, int serie,
+            int numeroInicial, int numeroFinal)
+        {
+            var numId = string.Concat((int)cUF, ano.ToString("D2"),
+                cnpj, (int)modelo,
+                serie.ToString().PadLeft(3, '0'),
+                numeroInicial.ToString().PadLeft(9, '0'),
+                numeroFinal.ToString().PadLeft(9, '0'));
+
+            return "ID" + numId;
         }
 
         /// <summary>


### PR DESCRIPTION
## O problema

Em arquiteturas onde a emissão roda num servidor mas o **certificado A3 é do
cliente e vive na máquina dele**, o servidor não tem — e não pode ter — a chave
privada usada para assinar. Ele fala com a SEFAZ com outro certificado, só para
o TLS. A assinatura precisa acontecer fora do servidor.

Para a **emissão** isso já funciona: `NFeAutorizacao4` recebe `List<NFe>` já
assinadas e apenas transmite. Para **eventos e inutilização** faltavam duas
peças:

**1. 7 dos 11 serviços de evento não tinham como receber o objeto já assinado.**
Só cancelamento, carta de correção, EPEC e perecimento tinham a sobrecarga que
recebe `List<evento>`. Os demais — incluindo a Manifestação do Destinatário —
existiam apenas na forma acoplada, que monta e assina com o certificado do
próprio processo. Quem assina fora do servidor simplesmente não conseguia usar
esses eventos.

**2. Não havia como obter o `@Id` sem assinar.**
O Id do elemento assinável (`infEvento/@Id`, `infInut/@Id`) só era calculado
dentro dos métodos que assinam. Como `Assina()` lança exceção se o Id vier
nulo, quem montasse o objeto por fora precisava reimplementar a regra de
formação na mão. Errar um dígito não dá erro em lugar nenhum: o digest deixa de
bater e a SEFAZ rejeita a assinatura.

## O que foi feito

- Sobrecarga `RecepcaoEventoX(int idlote, List<evento> eventos, bool assinar = false)`
  para os 7 serviços que faltavam. Com `assinar: false` (padrão) o evento é
  transmitido exatamente como veio; com `true` a biblioteca calcula o Id e
  assina com o certificado da instância.
- `Extevento.ObterId(tpEvento, chNFe, nSeqEvento)` e
  `ExtinutNFe.ObterId(cUF, ano, cnpj, modelo, serie, nNFIni, nNFFin)` —
  públicos, estáticos e de uso opcional.
- Testes de vetor ouro dos dois formatos de Id.

Cancelamento por substituição não precisou de método novo: usa o mesmo
`ServicoNFe.RecepcaoEventoCancelmento`, então a sobrecarga de cancelamento que
já existia atende.

Fluxo completo que passa a ser possível:

```csharp
// servidor: monta e resolve o Id, sem assinar
evento.infEvento.Id = Extevento.ObterId(tpEvento, chNFe, nSeqEvento);
var xml = evento.ObterXmlString();          // vai para a máquina cliente

// máquina cliente: assina com o A3
var naBorda = FuncoesXml.XmlStringParaClasse<evento>(xml);
naBorda.Assina(certificadoA3,
               cfg.Certificado.SignatureMethodSignedXml,
               cfg.Certificado.DigestMethodReference,
               cfg.RemoverAcentos);          // volta assinado

// servidor: só transmite
servicos.RecepcaoEventoManifestacaoDestinatario(idLote, new List<evento> { assinado });

▎ Atenção ao assinar na borda: removerAcentos tem default false em
▎ Assina(). Se o servidor usa RemoverAcentos = true, os três parâmetros de
▎ assinatura precisam ser os mesmos dos dois lados, senão o digest é calculado
▎ sobre um XML e transmitido outro.

Compatibilidade

Mudança puramente aditiva: 0 remoções. Nenhuma assinatura,
retorno ou corpo de método existente foi alterado.