### PR TITLE
feat: add grupo infDCe ao infDoc do CT-e (NT 2025.001)

### DIFF
--- a/CTe.Classes/Informacoes/infCTeNormal/infDoc.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDoc.cs
@@ -15,6 +15,13 @@ namespace CTe.Classes.Informacoes.infCTeNormal
         [XmlElement(ElementName = "infOutros")]
         public List<infOutros> infOutros { get; set; }
 
+        /// <summary>
+        ///     Informações das DCe (modelo 99) transportadas pelo CT-e.
+        ///     <para>Grupo criado pela NT 2025.001, disponível somente no leiaute 4.00.</para>
+        /// </summary>
+        [XmlElement(ElementName = "infDCe")]
+        public List<infDCe> infDCe { get; set; }
+
         public string nCont { get; set; }
 
         public string dPrev { get; set; }

--- a/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infDCe.cs
+++ b/CTe.Classes/Informacoes/infCTeNormal/infDocumentos/infDCe.cs
@@ -1,0 +1,21 @@
+using System.Xml.Serialization;
+
+namespace CTe.Classes.Informacoes.infCTeNormal.infDocumentos
+{
+    /// <summary>
+    ///     Informações das DCe (Declaração de Conteúdo eletrônica, modelo 99)
+    ///     transportadas pelo CT-e.
+    ///     <para>
+    ///         Grupo criado pela NT 2025.001 (item "Criação do grupo de informações da DCe nos
+    ///         documentos originários"), disponível somente no leiaute 4.00.
+    ///     </para>
+    /// </summary>
+    public class infDCe
+    {
+        /// <summary>
+        ///     Chave de acesso da DCe
+        /// </summary>
+        [XmlElement(Order = 1)]
+        public string chave { get; set; }
+    }
+}


### PR DESCRIPTION
A NT 2025.001 acrescentou o grupo infDCe ao choice de infDoc, permitindo vincular ao CT-e as Declarações de Conteúdo eletrônicas (modelo 99) transportadas. O grupo existe no cteTiposBasico_v4.00.xsd (elemento infDCe, filho único: chave do tipo TChDFe), mas não havia classe correspondente.

Sem ele, a única forma de declarar uma DC-e era infOutros com tpDoc=00 (Declaração), cujo nDoc tem maxLength=20 e não comporta a chave de 44 dígitos — vínculo em texto livre, que a SEFAZ não amarra ao documento.

O membro é declarado sem Order porque nenhum outro membro de infDoc usa: misturar membros ordenados e não ordenados na mesma classe faz o XmlSerializer lançar InvalidOperationException na sua construção.

Fonte: https://www.cte.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=k4vwqpRxU2M=